### PR TITLE
[Fix] Auto-close linked issues when a PR merges to any base branch

### DIFF
--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -280,3 +280,23 @@ jobs:
               owner, repo, issue_number: issueNumber, labels: [labelToAdd]
             });
             console.log(`✅ Issue #${issueNumber}: status:review → ${labelToAdd}`);
+
+      - name: Close Linked Issue on Merge
+        if: |
+          steps.parse-pr.outputs.has-issue == 'true' &&
+          github.event.pull_request.merged == true
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const issueNumber = parseInt('${{ steps.parse-pr.outputs.issue-number }}');
+            const owner       = context.repo.owner;
+            const repo        = context.repo.repo;
+
+            await github.rest.issues.update({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              state: 'closed',
+              state_reason: 'completed',
+            });
+            console.log(`✅ Issue #${issueNumber}: closed (merged)`);


### PR DESCRIPTION
# Description

Adds explicit issue closure to the `handle-closure` job in `pr-lifecycle.yml`. GitHub's native `Closes #N` keyword only fires when a PR merges into the default branch (`main`), so `feature → dev` merges leave linked issues permanently open with a `status:merged` label — a confusing divergence between label state and issue state. The new step closes the linked issue explicitly on any merge, regardless of the target base branch.

---

# Changes

- `.github/workflows/pr-lifecycle.yml` *(modified)*
  - added `Close Linked Issue on Merge` step to `handle-closure` job fires only when `merged == true` and a linked issue is present
  - sets `state: closed`, `state_reason: completed`
  - idempotent — closing an already-closed issue is a no-op in the GitHub API, no try/catch needed

---

# Self-review

- **CI checks:**
  - [x] CI passes on this PR

- **Manual verification** *(after merging a test PR to dev):*
  | Scenario | Expected | PR | Actual |
  |----------|----------|----|--------|
  | Merge `feature → dev` with linked issue | Issue closed, `status:merged` | #54 | Issue closed, `status:merged` |
  | Merge when issue already closed | No error, clean exit | #55 | No error, clean exit |
  | Close PR without merging | Issue stays open, `status:closed` | #56 | Issue stays open, `status:closed` |
  | Merge `dev → main` release PR | Issue closed, `status:merged` | — |

---

# Checklist

- [x] No source code or tests modified
- [x] No CHANGELOG entry required — CI infrastructure change only
- [x] CI passes

---

Closes #48
