### PR TITLE
[CI] Add branch name enforcement at CI and local hook level

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+"""
+commit-msg hook — validates branch name against recognised prefixes at commit time.
+
+This is the enforcement gate. Pair with post-checkout for early warning on
+branch creation. To enable (one-time setup):
+    git config core.hooksPath .githooks
+    chmod +x .githooks/commit-msg .githooks/post-checkout
+
+Skipped automatically on: main, dev, HEAD
+Reads rules from: .github/config/pr-labeling.json
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SKIP_BRANCHES = {"main", "dev", "HEAD"}
+
+
+def get_branch() -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def get_prefixes() -> list[str]:
+    config = Path(".github/config/pr-labeling.json")
+    with config.open() as f:
+        data = json.load(f)
+    return [entry["prefix"] for entry in data["branch_name_prefixes"]]
+
+
+def main() -> int:
+    branch = get_branch()
+
+    if branch in SKIP_BRANCHES:
+        return 0
+
+    prefixes = get_prefixes()
+
+    if any(branch.startswith(p) for p in prefixes):
+        return 0
+
+    # Load and format error message from template
+    template_path = Path(".githooks/templates/commit-blocked.txt")
+    error_message = template_path.read_text(encoding="utf-8").format(
+        branch=branch,
+        prefixes=", ".join(prefixes),
+    )
+    print(error_message, file=sys.stderr)
+    return 1  # Block the commit
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+"""
+post-checkout hook — warns immediately when a new branch is created with a
+non-standard name. Cannot block the operation (post-checkout exit code is
+ignored by git), but gives the developer early feedback before any commits
+are made.
+
+Pair with `commit-msg` which enforces the same rules and can block commits.
+
+Git passes three arguments:
+    $1 — previous HEAD
+    $2 — new HEAD
+    $3 — flag: 1 = branch checkout, 0 = file checkout
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SKIP_BRANCHES = {"main", "dev", "HEAD"}
+
+
+def get_branch() -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def get_prefixes() -> list[str]:
+    config = Path(".github/config/pr-labeling.json")
+    with config.open() as f:
+        data = json.load(f)
+    return [entry["prefix"] for entry in data["branch_name_prefixes"]]
+
+
+def main() -> int:
+    # Only run on branch checkouts, not file checkouts
+    # sys.argv: [script, prev_head, new_head, flag]
+
+    if len(sys.argv) < 4 or sys.argv[3] != "1":
+        return 0
+
+    branch = get_branch()
+
+    if branch in SKIP_BRANCHES:
+        return 0
+
+    prefixes = get_prefixes()
+
+    if any(branch.startswith(p) for p in prefixes):
+        return 0
+
+    # Load and format warning message from template
+    template_path = Path(".githooks/templates/branch-warning.txt")
+    warning_message = template_path.read_text(encoding="utf-8").format(
+        branch=branch,
+        prefixes=", ".join(prefixes),
+    )
+    print(warning_message, file=sys.stderr)
+    return 0  # Cannot block — exit code ignored by git for post-checkout
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -55,7 +55,7 @@ def main() -> int:
         return 0
 
     # Load and format warning message from template
-    template_path = Path(".githooks/templates/branch-warning.txt")
+    template_path = Path(".githooks/templates/checkout-warning.txt")
     warning_message = template_path.read_text(encoding="utf-8").format(
         branch=branch,
         prefixes=", ".join(prefixes),

--- a/.githooks/templates/checkout-warning.txt
+++ b/.githooks/templates/checkout-warning.txt
@@ -1,0 +1,18 @@
+===============================================================================
+  ⚠️  BRANCH NAMING WARNING
+===============================================================================
+
+  Current Branch Name  :  {branch}
+  Expected Branch Name :  <prefix>/issue-N_<slug>
+  Valid prefixes       :  {prefixes}
+
+===============================================================================
+  🔧 Fix now:  git branch -m {branch} <prefix>/issue-N_<slug>
+===============================================================================
+  💡 TIP: Haven't created a GitHub issue yet? No worries!
+     Create one first, then use that issue number in your branch name.
+     This keeps your work tracked and makes reviews much smoother.
+
+  ℹ️  Heads up: Commits on this branch will be blocked until you rename it.
+  📖 Check out .github/CONTRIBUTING.md for the full scoop on branch naming.
+===============================================================================

--- a/.githooks/templates/commit-blocked.txt
+++ b/.githooks/templates/commit-blocked.txt
@@ -1,0 +1,16 @@
+===============================================================================
+  ❌  COMMIT BLOCKED — BRANCH NAME ISSUE
+===============================================================================
+
+  Current Branch Name  :  {branch}
+  Expected Branch Name :  <prefix>/issue-N_<slug>
+  Valid prefixes       :  {prefixes}
+
+===============================================================================
+  🔧 Fix now:  git branch -m {branch} <prefix>/issue-N_<slug>
+===============================================================================
+  💡 TIP: Starting fresh? Create a GitHub issue first, then branch from it.
+     This keeps your work organized and code reviews straightforward.
+
+  📖 Check out .github/CONTRIBUTING.md for our branch naming conventions.
+===============================================================================

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,20 +1,20 @@
 # Contributing to PyConfigr
 
-Everything you need to contribute effectively — setup, branching, issues, PRs,
-and the automation that keeps it all in sync.
+Everything you need to contribute effectively — setup, branching, issues, PRs, and the automation that keeps it all in sync.
 
 ---
 
 ## Table of Contents
 
 1. [Development Setup](#development-setup)
-2. [Branch Naming](#branch-naming)
-3. [Working with Issues](#working-with-issues)
-4. [Opening a PR](#opening-a-pr)
-5. [What the Automation Does](#what-the-automation-does)
-6. [Release Process](#release-process)
-7. [Useful Queries](#useful-queries)
-8. [Troubleshooting](#troubleshooting)
+2. [Git Hooks](#git-hooks)
+3. [Branch Naming](#branch-naming)
+4. [Working with Issues](#working-with-issues)
+5. [Opening a PR](#opening-a-pr)
+6. [What the Automation Does](#what-the-automation-does)
+7. [Release Process](#release-process)
+8. [Useful Queries](#useful-queries)
+9. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -29,10 +29,11 @@ and the automation that keeps it all in sync.
 ```bash
 git clone https://github.com/aditya-barik/PyConfigr.git
 cd PyConfigr
+```
 
-uv venv
-source .venv/bin/activate
-uv pip install -e ".[dev]"
+### Create and Activate Virtual Environment, Install `dev` Dependencies
+```bash
+uv sync --extra dev
 ```
 
 ### Run Tests
@@ -47,15 +48,80 @@ mypy src/
 ```
 
 ---
+## Git Hooks
+
+Two opt-in local git hooks enforce branch naming conventions at different points:
+
+- **`post-checkout`** — warns immediately when you create a branch with a non-standard name. Cannot block the operation but gives instant feedback.
+- **`commit-msg`** — blocks commits on branches with non-standard names. This is the hard enforcement gate.
+
+Both hooks read from `.github/config/pr-labeling.json`, the same source of truth as the CI validation workflow.
+
+### Setup (one-time)
+
+Run the setup script using `uv` — works on Windows, macOS, and Linux:
+
+```bash
+uv run python scripts/setup-hooks.py
+```
+
+This configures git to use the hooks in `.githooks/` and sets the executable bit on each hook file.
+
+> **Note:** Ensure `git` is on your system PATH (check with `git --version` or `Get-Command git` in PowerShell). Also ensure `uv` is installed — if not, follow the official guide at https://docs.astral.sh/uv/getting-started/installation/. Both are required for the script to work correctly.
+
+### What you will see
+
+On branch creation with a bad branch name (`post-checkout` — warning only):
+```
+===============================================================================
+  ⚠️  BRANCH NAMING WARNING
+===============================================================================
+
+  Current Branch Name  :  bad_branch_name
+  Expected Branch Name :  <prefix>/issue-N_<slug>
+  Valid prefixes       :  fix/, feature/, docs/, refactor/, ci/, test/
+
+===============================================================================
+  🔧 Fix now:  git branch -m bad_branch_name <prefix>/issue-N_<slug>
+===============================================================================
+  💡 TIP: Haven't created a GitHub issue yet? No worries!
+     Create one first, then use that issue number in your branch name.
+     This keeps your work tracked and makes reviews much smoother.
+
+  ℹ️  Heads up: Commits on this branch will be blocked until you rename it.
+  📖 Check out .github/CONTRIBUTING.md for the full scoop on branch naming.
+===============================================================================
+```
+
+On commit with a bad branch name (`commit-msg` — blocks the commit):
+```
+===============================================================================
+  ❌  COMMIT BLOCKED — BRANCH NAME ISSUE
+===============================================================================
+
+  Current Branch Name  :  bad_branch_name
+  Expected Branch Name :  <prefix>/issue-N_<slug>
+  Valid prefixes       :  fix/, feature/, docs/, refactor/, ci/, test/
+
+===============================================================================
+  🔧 Fix now:  git branch -m bad_branch_name <prefix>/issue-N_<slug>
+===============================================================================
+  💡 TIP: Starting fresh? Create a GitHub issue first, then branch from it.
+     This keeps your work organized and code reviews straightforward.
+
+  📖 Check out .github/CONTRIBUTING.md for our branch naming conventions.
+===============================================================================
+```
+
+Both hooks pass silently on `main`, `dev`, and `HEAD`. The hooks are **opt-in** — they are never enforced automatically on the runner.
+
+---
+
 ## Branch Naming
 
-Branch name prefixes drive automatic PR labelling. Use them consistently.
-If your branch name doesn't match any prefix — for example when working from a fork
-or a hotfix branch with a non-standard name — the automation falls back to matching
-the PR title pattern instead.
+Branch name prefixes drive automatic PR labelling. Use them consistently. If your branch name doesn't match any prefix — for example when working from a fork or a hotfix branch with a non-standard name — the automation falls back to matching the PR title pattern instead.
 
-See `.github/config/pr-labeling.json` for the full mapping. Adding a new convention
-is a one-line change to that file.
+See `.github/config/pr-labeling.json` for the full mapping. Adding a new convention is a one-line change to that file.
 
 ### Branch Name Prefixes (Primary)
 
@@ -82,15 +148,52 @@ Used only when the branch name does not match any prefix above.
 | `[Test]` | `type:test` | `[Test] Add edge cases for TOML loader` |
 | `[Release]` | `type:release` | `[Release] vX.Y.Z` |
 
-> **Priority:** Branch prefix is always checked first. PR title pattern is only
-> used as a fallback. If neither matches, no type label is applied — only
-> `status:review` is added.
+> **Priority:** Branch prefix is always checked first. PR title pattern is only used as a fallback. If neither matches, no type label is applied — only `status:review` is added.
 >
-> **Note:** `[Release]` is the only pattern without a corresponding branch
-> prefix — release PRs always originate from the `dev` branch directly.
+> **Note:** `[Release]` is the only pattern without a corresponding branch prefix — release PRs always originate from the `dev` branch directly.
+
 ---
 
 ## Working with Issues
+
+### Issue Document Format
+
+Before opening a GitHub issue, create a Markdown file in `planned-issues/` using the template below. This keeps intent, rationale, and scope in version control and makes it easy to review planned work before acting on it.
+
+```markdown
+# Issue N — <Short Title>
+
+**Branch:** `<prefix>/issue-N_<slug>`
+**Labels:** `type:...` · `area:...`
+**Depends on:** *(optional)*
+
+---
+
+## Summary
+
+<!-- One or two sentences describing the problem or goal and why it matters. -->
+
+---
+
+## What to Change/Solve/Update/Evolve
+
+<!-- Bullet list of concrete changes. Include before/after snippets where helpful. -->
+
+---
+
+## Scope of Changes
+
+**Files touched:**
+- `path/to/file` *(new file / modified)*
+
+**Acceptance criteria:**
+- <!-- Observable, verifiable outcome 1 -->
+- <!-- Observable, verifiable outcome 2 -->
+```
+
+See `planned-issues/` for real examples.
+
+---
 
 ### Creating an Issue
 
@@ -166,8 +269,7 @@ Fixes #42
 Resolves #42
 ```
 
-This is required for the automation to sync labels and milestones to the issue,
-and for GitHub to close the issue automatically when the PR merges.
+This is required for the automation to sync labels and milestones to the issue and for GitHub to close the issue automatically when the PR merges.
 
 **Recommended PR description format:**
 ```markdown
@@ -187,8 +289,7 @@ Closes #42
 
 ### Step 4 — Automation handles the rest
 
-Once the PR is open, the `PR and Issue Lifecycle` workflow runs automatically.
-See [What the Automation Does](#what-the-automation-does) below.
+Once the PR is open, the `PR and Issue Lifecycle` workflow runs automatically. See [What the Automation Does](#what-the-automation-does) below.
 
 ---
 

--- a/.github/templates/pr-invalid-branch.md
+++ b/.github/templates/pr-invalid-branch.md
@@ -1,0 +1,8 @@
+❌ **Non-standard branch name: `{BRANCH_NAME}`**
+
+Branch names must start with a recognised prefix.
+
+**Recognised prefixes:** {PREFIXES}
+
+Either rename your branch to match a recognised prefix, or add a matching title pattern (e.g. `[Fix]`, `[CI]`) as a fallback.
+See [CONTRIBUTING.md](../blob/main/.github/CONTRIBUTING.md#branch-naming) for conventions.

--- a/.github/templates/pr-missing-issue.md
+++ b/.github/templates/pr-missing-issue.md
@@ -1,0 +1,9 @@
+❌ **Missing linked issue**
+
+This PR must reference a GitHub issue in the description using one of:
+- `Closes #N`
+- `Fixes #N`
+- `Resolves #N`
+
+Please update the PR description and push a new commit to re-run this check.
+See [CONTRIBUTING.md](../blob/main/.github/CONTRIBUTING.md#opening-a-pr) for details.

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,0 +1,104 @@
+name: Validate PR
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  validate:
+    name: Validate PR Requirements
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Check Linked Issue
+        id: check-issue
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const body  = context.payload.pull_request.body ?? '';
+            const match = body.match(/(?:Closes|Fixes|Resolves)\s+#(\d+)/i);
+
+            if (match) {
+              console.log(`✅ Linked issue found: #${match[1]}`);
+              core.setOutput('failed', 'false');
+              return;
+            }
+
+            console.log('❌ No linked issue found in PR body.');
+            core.setOutput('failed', 'true');
+
+            const fs      = require('fs');
+            const path    = require('path');
+            const tplPath = path.join(
+              process.env.GITHUB_WORKSPACE,
+              '.github/templates/pr-missing-issue.md'
+            );
+            const comment = fs.readFileSync(tplPath, 'utf8');
+
+            await github.rest.issues.createComment({
+              owner:        context.repo.owner,
+              repo:         context.repo.repo,
+              issue_number: context.issue.number,
+              body:         comment,
+            });
+
+      - name: Check Branch Name
+        id: check-branch
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+
+            // Release PRs always originate from dev — exempt from branch check
+            if (branch === 'dev') {
+              console.log('⏭️  Release PR from dev — branch name check skipped.');
+              core.setOutput('failed', 'false');
+              return;
+            }
+
+            const fs = require('fs');
+            const path = require('path');
+            const { branch_name_prefixes } = JSON.parse(
+              fs.readFileSync('.github/config/pr-labeling.json', 'utf8')
+            );
+
+            const prefixes = branch_name_prefixes.map(({ prefix }) => prefix);
+            const valid    = prefixes.some(p => branch.startsWith(p));
+
+            if (valid) {
+              console.log(`✅ Branch '${branch}' matches a recognised prefix.`);
+              core.setOutput('failed', 'false');
+              return;
+            }
+
+            console.log(`❌ Branch '${branch}' does not match any recognised prefix.`);
+            core.setOutput('failed', 'true');
+
+            const tplPath = path.join(
+              process.env.GITHUB_WORKSPACE,
+              '.github/templates/pr-invalid-branch.md'
+            );
+            let comment = fs.readFileSync(tplPath, 'utf8');
+            comment = comment
+              .replace('{BRANCH_NAME}', branch)
+              .replace('{PREFIXES}',    prefixes.map(p => `\`${p}\``).join(' · '));
+
+            await github.rest.issues.createComment({
+              owner:        context.repo.owner,
+              repo:         context.repo.repo,
+              issue_number: context.issue.number,
+              body:         comment,
+            });
+
+      - name: Fail if any check failed
+        if: |
+          steps.check-issue.outputs.failed == 'true' ||
+          steps.check-branch.outputs.failed == 'true'
+        run: |
+          echo "One or more PR validation checks failed. See PR comments for details."
+          exit 1

--- a/scripts/setup-hooks.py
+++ b/scripts/setup-hooks.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+"""
+One-time git hook setup for PyConfigr.
+
+Run with:
+    uv run python scripts/setup-hooks.py
+
+Configures git to use the hooks in `.githooks/` and sets the executable
+bit on each hook file. Works on Windows, macOS, and Linux.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+HOOKS = [
+    ".githooks/commit-msg",
+    ".githooks/post-checkout",
+]
+
+
+def main() -> int:
+    root = Path(__file__).parent.parent
+
+    result = subprocess.run(
+        ["git", "config", "core.hooksPath", ".githooks"],
+        cwd=root,
+    )
+    if result.returncode != 0:
+        print("❌ Failed to set core.hooksPath.", file=sys.stderr)
+        return 1
+
+    for hook in HOOKS:
+        hook_path = root / hook
+        if not hook_path.exists():
+            print(f"⚠️  Hook not found, skipping: {hook}")
+            continue
+        hook_path.chmod(0o755)
+        print(f"✅ Executable bit set: {hook}")
+
+    print("\n✅ Git hooks configured. You're all set.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# Description

Adds branch name enforcement at two levels using `pr-labeling.json` as the single source of truth. `validate-pr.yml` blocks non-conforming PRs at CI time with comments loaded from reusable template files. Two opt-in local git hooks provide a two-stage developer experience: `post-checkout` warns immediately on bad branch creation (cannot block), and `commit-msg` hard-blocks commits until the branch is renamed. Release PRs from `dev` are exempt from the branch name check.

---

# Changes

- `.github/workflows/validate-pr.yml` *(new file)*
  - triggers on PR `opened`, `reopened`, `synchronize`
  - check 1: PR body must contain `Closes/Fixes/Resolves #N`; posts `pr-missing-issue.md` on failure
  - check 2: head branch must match a prefix from `pr-labeling.json`; posts `pr-invalid-branch.md` on failure; `dev` branch exempt
  - both checks always run before job fails — author sees all issues at once

- `.github/templates/pr-missing-issue.md` *(new file)*
  - comment body for missing linked issue check failure

- `.github/templates/pr-invalid-branch.md` *(new file)*
  - comment body for invalid branch name check failure
  - `{BRANCH_NAME}` and `{PREFIXES}` substituted at runtime

- `.githooks/post-checkout` *(new file, Python script)*
  - fires on branch checkout (arg flag `== "1"`), not file checkout
  - prints warning from `checkout-warning.txt` if prefix unrecognised
  - cannot block the operation — exit code ignored by git
  - skips `main`, `dev`, `HEAD`

- `.githooks/commit-msg` *(new file, Python script)*
  - fires on every commit; blocks if branch name is unrecognised
  - prints error from `commit-blocked.txt`
  - reads prefixes from `.github/config/pr-labeling.json`
  - skips `main`, `dev`, `HEAD`

- `.githooks/templates/commit-blocked.txt` *(new file)*
  - error message template; `{branch}` and `{prefixes}` substituted at runtime

- `.githooks/templates/checkout-warning.txt` *(new file)*
  - warning message template; `{branch}` and `{prefixes}` substituted at runtime

- `scripts/setup-hooks.py` *(new file)*
  - cross-platform hook setup: sets `core.hooksPath` and executable bit on all hooks; run with `uv run python scripts/setup-hooks.py`

- `.github/CONTRIBUTING.md` *(modified)*
  - added Git Hooks section: both hooks explained, cross-platform setup command, example output for warning and error cases

---

# Self-review

- **Static checks — verified locally:**
  - [x] Both CI check steps use `core.setOutput` not `core.setFailed` — both checks always run before the job fails
  - [x] Template files read via `GITHUB_WORKSPACE` — consistent with other template file patterns in the repo
  - [x] `dev` branch exemption present in branch name check
  - [x] `post-checkout` checks `sys.argv[3] == "1"` — does not fire on file checkouts
  - [x] Both hooks use `#!/usr/bin/env python` — Windows compatible
  - [x] Both hooks skip `main`, `dev`, `HEAD`
  - [x] `permissions: pull-requests: write` only — least privilege
  - [x] Hook behaviour verified locally: bad branch warns on creation, blocks on commit; valid branch passes silently

- **CI checks:**
  - [x] CI passes on this PR

- **Manual verification:**
  | Scenario | Expected | Actual |
  |----------|----------|--------|
  | PR without `Closes #N` | Check fails, comment posted | ✅ |
  | PR with bad branch name | Check fails, comment posted | ✅ |
  | PR with both correct | Check passes | ✅ |
  | `dev → main` release PR | Branch check skipped | — |
  | `git checkout -b bad-branch` | post-checkout warning printed | ✅ |
  | `git switch -c bad-branch` | post-checkout warning printed | ✅ |
  | Commit on `bad-branch` | commit-msg blocks with error | ✅ |
  | Commit on `fix/issue-50_...` | Both hooks pass silently | ✅ |
  | Commit on `main` or `dev` | Both hooks pass silently | ✅ |

---

# Checklist

- [x] No source code or tests modified
- [x] No CHANGELOG entry required — CI infrastructure change only
- [x] CI passes

---

Closes #50
