### PR TITLE
[CI] Add main → dev post-release sync workflow

### DIFF
--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -1,3 +1,35 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# PR and Issue Lifecycle
+#
+# Manages labels, issue sync, and milestone sync across the full PR lifecycle.
+# Runs three jobs depending on the PR event type:
+#
+#   ensure-labels   — guarantees every label referenced by the other jobs
+#                     exists before they attempt to apply it; runs on all
+#                     PR events
+#
+#   label-pr        — runs on open/reopen/synchronize:
+#                     1. detects type label from branch prefix or PR title
+#                        using pr-labeling.json
+#                     2. applies status:review + type label to the PR
+#                     3. syncs the same labels to the linked issue
+#                     4. syncs milestones between PR and linked issue;
+#                        posts a conflict comment if they differ
+#
+#   handle-closure  — runs on closed:
+#                     1. swaps status:review → status:merged or status:closed
+#                        on both the PR and the linked issue
+#                     2. explicitly closes the linked issue on merge
+#                        (GitHub native auto-close only fires for main;
+#                        this covers feature → dev merges)
+#
+# Requires: Closes/Fixes/Resolves #N in the PR body for issue sync to work.
+# Config:   .github/config/labels.json, .github/config/pr-labeling.json
+# Templates: .github/templates/milestone-conflict.md
+#
+# Triggered by : pull_request [opened, reopened, synchronize, closed]
+# ─────────────────────────────────────────────────────────────────────────────
+
 name: PR and Issue Lifecycle
 
 on:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,3 +1,28 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Python Package CI
+#
+# The primary CI pipeline. Runs on every push to main/dev and on every PR
+# targeting main/dev. Executes five jobs in sequence:
+#
+#   lint       — Ruff static analysis; uploads results as an artifact
+#   types      — MyPy strict type checking
+#   test       — pytest unit tests across Python 3.10–3.14 (matrix)
+#                uploads per-version coverage reports to Codecov
+#   build      — builds the wheel; uploads as an artifact
+#   integration — installs the built wheel into a clean venv and runs
+#                 integration tests against Python 3.10 (minimum supported)
+#
+# Job dependency chain:
+#   lint ─┐
+#         ├─→ test ─→ build ─→ integration
+#   types ┘
+#
+# Version constants are centralised in the top-level env: block.
+# Python is installed via actions/setup-python; uv manages the venv.
+#
+# Triggered by : push to main/dev, pull_request targeting main/dev
+# ─────────────────────────────────────────────────────────────────────────────
+
 name: Python Package CI
 
 on:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,3 +1,19 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Sync Labels
+#
+# Keeps GitHub's label set in sync with the versioned source of truth at
+# .github/config/labels.json. Creates missing labels and updates existing
+# ones (name, colour, description). Never deletes labels.
+#
+# Run this workflow whenever labels.json is updated, or manually from the
+# Actions tab to repair labels that were modified directly in the GitHub UI.
+#
+# Config: .github/config/labels.json
+#
+# Triggered by : push to main when labels.json changes
+#                workflow_dispatch (manual)
+# ─────────────────────────────────────────────────────────────────────────────
+
 name: Sync Labels
 
 on:

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -1,0 +1,82 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Sync main → dev
+#
+# Opens a PR to sync release commits from `main` back to `dev` after every
+# push to `main`. Without this, CHANGELOG updates and version bumps that land
+# on `main` during a release must be manually synced, causing merge conflicts
+# on the next release cycle.
+#
+# The workflow is fully idempotent:
+#   - if `main` and `dev` are already identical, no PR is created
+#   - if a sync PR is already open, no duplicate is created
+#   - all no-op paths exit cleanly with a descriptive log message
+#
+# Triggered by : push to `main` (covers PR merges and direct pushes)
+# Manual run   : workflow_dispatch (for testing before first real release)
+# Permissions  : contents:read, pull-requests:write
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: Sync main → dev
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  sync:
+    name: Open main → dev sync PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check if branches are already in sync
+        id: check-sync
+        run: |
+          git fetch origin main dev
+          if git diff --quiet origin/main origin/dev; then
+            echo "✅ main and dev are already in sync — nothing to do."
+            echo "in-sync=true" >> $GITHUB_OUTPUT
+          else
+            echo "🔀 main is ahead of dev — sync PR needed."
+            echo "in-sync=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for existing open sync PR
+        id: check-existing
+        if: steps.check-sync.outputs.in-sync == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          COUNT=$(gh pr list \
+            --base dev \
+            --head main \
+            --state open \
+            --json number \
+            --jq length)
+          echo "existing=$COUNT" >> $GITHUB_OUTPUT
+          if [ "$COUNT" -gt 0 ]; then
+            echo "⏭️  Sync PR already open — skipping creation."
+          fi
+
+      - name: Open sync PR
+        if: |
+          steps.check-sync.outputs.in-sync == 'false' &&
+          steps.check-existing.outputs.existing == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base dev \
+            --head main \
+            --title "[CI] Sync main → dev after release" \
+            --body "Automated sync of release commits from \`main\` back to \`dev\`."
+          echo "✅ Sync PR opened."

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,3 +1,30 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Validate PR
+#
+# Enforces two structural rules on every PR before other workflows run:
+#
+#   1. Linked issue   — PR body must contain Closes/Fixes/Resolves #N.
+#                       Required for pr-lifecycle.yml label and milestone
+#                       sync to function correctly.
+#
+#   2. Branch name    — Head branch must start with a recognised prefix
+#                       from .github/config/pr-labeling.json. Release PRs
+#                       from `dev` are exempt from this check.
+#
+# Both checks always run before the job fails so the author sees all
+# problems in one pass rather than fix-and-rerun. On failure, a comment
+# is posted on the PR with the exact correction needed.
+#
+# This workflow is configured as a required status check on `dev` and
+# `main` via branch protection rules, making it a hard merge gate.
+#
+# Config:    .github/config/pr-labeling.json
+# Templates: .github/templates/pr-missing-issue.md
+#            .github/templates/pr-invalid-branch.md
+#
+# Triggered by : pull_request [opened, reopened, synchronize]
+# ─────────────────────────────────────────────────────────────────────────────
+
 name: Validate PR
 
 on:


### PR DESCRIPTION
# Description

Adds a dedicated workflow that automatically opens a `main → dev` sync PR after every push to `main`. Without this, release commits (CHANGELOG updates, version bumps) must be manually synced back to `dev`, causing merge conflicts on the next release cycle. The workflow is fully idempotent — it exits cleanly if the branches are already in sync or if a sync PR is already open.

Also adds `workflow_dispatch` as a second trigger so the workflow can be tested manually from the Actions tab before the first real release merge.

Also adds descriptive YAML comment headers to all five workflow files documenting purpose, job structure, triggers, and dependencies.

---

# Changes

- `.github/workflows/sync-main-to-dev.yml` *(new file)*
  - triggers on `push` to `main` and `workflow_dispatch`
  - step 1: `git diff` to check if branches are already in sync
  - step 2: `gh pr list` to check for existing open sync PR
  - step 3: `gh pr create` to open the sync PR
  - idempotent across all three execution paths
  - permissions: `contents:read`, `pull-requests:write`

- `.github/workflows/python-package.yml` *(modified)*
  - added descriptive YAML comment header

- `.github/workflows/pr-lifecycle.yml` *(modified)*
  - added descriptive YAML comment header

- `.github/workflows/sync-labels.yml` *(modified)*
  - added descriptive YAML comment header

- `.github/workflows/validate-pr.yml` *(modified)*
  - added descriptive YAML comment header

---

# Self-review

- **Static checks — verified locally:**
  - [x] `fetch-depth: 0` on checkout — required for cross-branch diff
  - [x] `GITHUB_TOKEN` used — no PAT required
  - [x] All three exit paths produce clean output with descriptive logs
  - [x] `workflow_dispatch` trigger added — enables manual testing before first real release

- **CI checks:**
  - [x] CI passes on this PR

- **Manual verification** *(using workflow_dispatch before release):*
  | Scenario | Expected | Actual |
  |----------|----------|--------|
  | Trigger manually when `main` = `dev` | No PR, clean exit | ✅ |
  | Trigger manually when `main` ahead of `dev` | Sync PR opened | — |
  | Trigger again with sync PR already open | No duplicate, clean exit | — |
  | Merge release PR | Sync PR opened automatically | — |

---

# Checklist

- [x] No source code or tests modified
- [x] No CHANGELOG entry required — CI infrastructure change only
- [x] CI passes

---

Closes #49
