### PR TITLE
[Fix] Exempt dev → main PRs from validate-pr linked issue check

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -47,6 +47,16 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
+            const branch = context.payload.pull_request.head.ref;
+
+            // Release/integration PRs from dev are exempt from the issue
+            // link check — they represent collected work, not a single issue
+            if (branch === 'dev') {
+              console.log('⏭️  Integration PR from dev — issue link check skipped.');
+              core.setOutput('failed', 'false');
+              return;
+            }
+
             const body  = context.payload.pull_request.body ?? '';
             const match = body.match(/(?:Closes|Fixes|Resolves)\s+#(\d+)/i);
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Posts a template comment on failure so the author knows exactly what to fix
   - Both checks always run before the job fails
   - `dev` branch exempt from the branch name check (release PRs)
+  - `dev` branch exempt from the linked issue check (integration PRs)
   - Configured as a required status check on `dev` and `main`
 - **Added `.githooks/post-checkout`** — warns immediately when a branch is created with an unrecognised name; cannot block (exit code ignored by git)
 - **Added `.githooks/commit-msg`** — blocks commits on branches with unrecognised names; hard enforcement gate; skips `main`, `dev`, `HEAD`


### PR DESCRIPTION
# Description

The `validate-pr.yml` workflow introduced in Issue #50 correctly exempts `dev → main` PRs from the branch name check, but applies the linked issue check unconditionally. This causes every `dev → main` integration PR to fail validation with a "missing linked issue" comment, blocking the merge button on PRs that represent collected work across multiple already-reviewed issues.

This fix extends the existing `dev` branch exemption to the linked issue check, making the two checks consistent with each other.

---

# Changes

- `.github/workflows/validate-pr.yml` *(modified)*
  - added `head.ref === 'dev'` exemption to `Check Linked Issue` step
  - mirrors the identical exemption already present in `Check Branch Name`
  - `dev → main` PRs now skip both checks cleanly with a log message

---

# Self-review

- **Static checks — verified locally:**
  - [x] Exemption condition is identical in both check steps — `head.ref === 'dev'` in both cases
  - [x] Exemption fires before any API calls — no comment is posted on exempt PRs
  - [x] No other logic changed in the workflow

- **CI checks:**
  - [x] CI passes on this PR

- **Manual verification:**
  | Scenario | Expected | Actual |
  |----------|----------|--------|
  | `dev → main` PR | Both checks skipped, job passes | ✅ |
  | `feature/* → dev` without `Closes #N` | Issue check fails, comment posted | ✅ |
  | `feature/* → dev` with bad branch name | Branch check fails, comment posted | ✅ |
  | `feature/* → dev` with both correct | Both checks pass | ✅ |

---

# Checklist

- [x] No source code or tests modified
- [x] CI passes

---

Closes #65
