### PR TITLE
[Feature] Introduce `RawConfigBuilder` and `build_dict()` — schema-free configuration pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] - Unreleased
 
-### ⚙️ CI/CD
+### ✨ New Features
+
+- **`RawConfigbuilder` class** (`builder.py`) — Schema-free configuration pipeline. Provides the full loading, merging, and priority system without requiring a Pydantic model. All pipeline methods (`from_file`, `from_env`, `from_dict`, `set`, `peek`) live on this base class.
+- **`build_dict()` terminal method** (`builder.py`) — Returns the final merged configuration as a plain dictionary. this is the terminal method for schema-free pipelines, analogous to `build()` on `ConfigBuilder`.
+
+### 🔄 Changed
+
+- **`ConfigBuilder` now extends `RawConfigBuilder`** (`builder.py`) — Two-class split: `RawConfigBuilder` is the base class with all pipeline logic; `ConfigBuilder(RawConfigBuilder, Generic[T])` adds typed Pydantic validation via `build()`. All existing `ConfigBuilder` usage is fully backwards-compatible.
+- **Fluent method return types use `Self`** (`builder.py`) — Pipeline methods now return `typing_extensions.Self` instead of a string-literal fprward reference. This gives correct return types through inheritance: calling `.from_file()` on a `ConfigBuilder[AppConfig]` returns `ConfigBuilder[AppConfig]`, not `RawConfigBuilder`.
+- **`RawConfigBuilder` added to public API** (`__init__.py`) — importable via `from pyconfigr import RawConfigBuilder` and included in `__all__`.
+- **Version bumped to `0.2.0`** (`pyproject.toml`)
+
+### 🧪 Tests
+
+- Expanded `tests/unit/test_builder.py` — 57 tests total mirroring `src/pyconfigr/builder.py`: 39 tests covering `RawConfigBuilder` (parent) pipeline, exception handling and inheritance; 18 tests for `ConfigBuilder` (child) smoke tests with `build()`, Pydantic validation, integration, and the shared `_deep_merge` utility.
+
+### 🤖 CI/CD
 
 - **Renamed `ci.yaml` → `python-package.yml`** — follows GitHub Actions naming convention for package workflows
 - **Centralised version constants** (`python-package.yml`) — `UV_VERSION` and `INTEGRATION_PYTHON_VERSION` moved to a top-level `env:` block; no more hardcoded values scattered across jobs

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![codecov](https://codecov.io/github/aditya-barik/PyConfigr/graph/badge.svg?token=II8VJY2FOM)](https://codecov.io/github/aditya-barik/PyConfigr)
 [![Type Safe](https://img.shields.io/badge/type%20safe-mypy-blue)](http://mypy-lang.org/)
 
-PyConfigr bridges the gap between manual configuration management and heavyweight tools. It combines **Pydantic's robust validation** with support for **multiple formats** (YAML, JSON, TOML), **environment variables**, and a **fluent API** that reads like natural Python. Whether you're building microservices, web applications, or CLI tools, PyConfigr handles configuration without getting in the way.
+PyConfigr bridges the gap between manual configuration management and heavyweight tools. It combines **Pydantic's robust validation** with support for **multiple formats** (YAML, JSON, TOML), **environment variables**, and a **fluent API** that reads like natural Python. Need the pipeline without a schema? PyConfigr has you covered with `RawConfigBuilder`. Whether you're building microservices, web applications, or CLI tools, PyConfigr handles configuration without getting in the way.
 
 ## ✨ Why PyConfigr?
 
@@ -25,6 +25,7 @@ PyConfigr bridges the gap between manual configuration management and heavyweigh
 - **⛓️ Fluent API**: Chainable methods that read naturally
 - **🎯 Format Auto-Detection**: Automatically identify and parse files
 - **🐍 Modern Python**: Full type hints and Python 3.10+ syntax
+- **   Schema-Free Option**: Use `RawConfigBuilder` when you just need a merged `dict` — no Pydantic required
 - **🪶 Lightweight**: Only `pydantic` and `pyyaml` required for core functionality
 
 ## 🚀 Getting Started
@@ -66,6 +67,27 @@ print(f"Server: {config.host}:{config.port}")
 ```
 
 **That's it.** Three lines of configuration loading. Three sources merged intelligently. Full type safety throughout.
+
+### Schema-Free Alternative
+
+Don't need typed validation? Use `RawConfigBuilder` to get a plain dictionary:
+
+```python
+from pyconfigr import RawConfigBuilder
+
+raw_config = (
+    RawConfigBuilder()
+    .from-file("config.yaml")
+    .from_env("MYAPP_")
+    .set("debug", True)  # Explicit override
+    .build_dict()
+)
+
+# config is a plain dict — no schema needed
+print(f"Port: {raw_config['port']}")
+```
+
+Same pipeline, same priority system, same multi-format support — just without the Pydantic model.
 
 ## � Common Patterns
 
@@ -134,7 +156,32 @@ print(f"DB: {config.database.host}:{config.database.port}")
 print(f"Cache TTL: {config.cache.ttl_seconds}s")
 ```
 
-### Pattern 4: Validation with Constraints
+### Pattern 4: Schema-Free Configuration
+
+use `RawConfigBuilder` when you need the pipeline but not the validation — scripts, CLI tools, migrations, or quick prototypes:
+
+```python
+from pyconfigr import RawConfigBuilder
+
+# Full pipeline, plain dict output
+raw_config = (
+    RawConfigBuilder()
+    .from_file("config/default.yaml")
+    .from_env("MYAPP_")
+    .from_dict({"timeout": 30})
+    .build_dict()
+)
+
+# inspect mid-chain without finalising
+raw_builder = RawConfigBuilder().from_file("config.yaml")
+print(raw_builder.peek())  # snapshot of current state
+raw_builder.set("port", 9000)
+raw_config = raw_builder.build_dict()
+```
+
+`RawConfigBuilder` shares the exact same loading, merging, and priority logic as `ConfigBuilder` — it just skips the Pydantic validation step.
+
+### Pattern 5: Validation with Constraints
 
 Let Pydantic enforce your business rules:
 
@@ -360,9 +407,9 @@ chmod 600 config/production.yaml
 
 | Aspect | Status |
 |--------|--------|
-| **Version** | 0.1.0 (Initial Release) |
+| **Version** | 0.2.0 |
 | **Python Support** | 3.10, 3.11, 3.12, 3.13, 3.14 |
-| **Test Coverage** | ~98% (105 tests) |
+| **Test Coverage** | ~100% (200 tests) |
 | **Type Checking** | Full MyPy strict compliance |
 | **CI/CD** | GitHub Actions (multi-version testing) |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyconfigr"
-version = "0.1.1"
+version = "0.2.0"
 description = "Flexible configuration management with Pydantic validation, YAML/JSON/TOML support, and fluent API"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyconfigr/__init__.py
+++ b/src/pyconfigr/__init__.py
@@ -7,7 +7,18 @@ testable configuration code.
 
 Examples
 --------
-Basic usage with Pydantic validation::
+Schema-less usage (no Pydantic needed)::
+
+    from pyconfigr import RawConfigBuilder
+
+    raw_config = (
+        RawConfigBuilder()
+        .from_file("config.yaml")
+        .from_env("MYAPP_")
+        .build_dict()
+    )
+
+Typed usage with Pydantic validation::
 
     from pydantic import BaseModel
     from pyconfigr import ConfigBuilder
@@ -44,7 +55,7 @@ Inspect assembled data before validating::
 
 from importlib.metadata import PackageNotFoundError, version
 
-from .builder import ConfigBuilder
+from .builder import ConfigBuilder, RawConfigBuilder
 from .exceptions import (
     ConfigError,
     ConfigLoadError,
@@ -55,10 +66,11 @@ from .exceptions import (
 try:
     __version__ = version("pyconfigr")
 except PackageNotFoundError:  # pragma: no cover
-    __version__ = "0.1.1.dev0"
+    __version__ = "0.2.0.dev0"
 
 __all__ = [
     "ConfigBuilder",
+    "RawConfigBuilder",
     "ConfigError",
     "ConfigLoadError",
     "ConfigNotFoundError",

--- a/src/pyconfigr/builder.py
+++ b/src/pyconfigr/builder.py
@@ -1,8 +1,12 @@
 """
-Fluent API builder for configuration management.
+Fluent API builders for configuration management.
 
-This module provides :class:`ConfigBuilder`, which assembles configuration
-from multiple sources and validates the result against a Pydantic model.
+This module provides two public classes:
+
+- :class:`RawConfigBuilder` — the pure pipeline (loading, merging, priority).
+  No schema required.  Terminal method: :meth:`~RawConfigBuilder.build_dict`.
+- :class:`ConfigBuilder` — extends :class:`RawConfigBuilder` with typed Pydantic
+  validation.  Terminal method: :meth:`~ConfigBuilder.build`.
 """
 
 import warnings
@@ -10,6 +14,7 @@ from pathlib import Path
 from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel, ValidationError
+from typing_extensions import Self
 
 from .exceptions import ConfigLoadError, ConfigNotFoundError, ConfigValidationError
 from .loaders import ConfigLoader
@@ -17,9 +22,14 @@ from .loaders import ConfigLoader
 T = TypeVar("T", bound=BaseModel)
 
 
-class ConfigBuilder(Generic[T]):
+# ======================================================================
+# RawConfigBuilder — schema-free pipeline
+# ======================================================================
+
+
+class RawConfigBuilder:
     """
-    Fluent API builder for loading, merging, and validating configuration.
+    Schema-free configuration pipeline — loading, merging, and priority.
 
     Sources are merged in the order they are added — later sources take
     priority over earlier ones.  Nested dicts are merged recursively; all
@@ -28,6 +38,351 @@ class ConfigBuilder(Generic[T]):
     Priority (lowest → highest)
     ---------------------------
     ``from_file`` → ``from_env`` → ``from_dict`` → ``set``
+
+    Use :meth:`build_dict` to obtain the final merged dictionary, or
+    :meth:`peek` to inspect the state mid-chain without finalising.
+
+    Examples
+    --------
+    Schmea-less usage::
+
+        from pyconfigr import RawConfigBuilder
+
+        raw_config = (
+            RawConfigBuilder()
+            .from_file("config.yaml")
+            .from_env("MYAPP_")
+            .build_dict()
+        )
+
+    Inspect assembled data mid-chain::
+
+        builder = RawConfigBuilder().from_file("app.yaml").from_env("MYAPP_")
+        print(builder.peek())   # plain dict — pipeline not finalised
+        config = builder.build_dict()
+    """
+
+    def __init__(self) -> None:
+        """Initialise an empty pipeline with no sources."""
+        self._data: dict[str, Any] = {}
+
+    # ------------------------------------------------------------------
+    # Source methods
+    # ------------------------------------------------------------------
+
+    def from_file(self, path: str | Path, optional: bool = False) -> Self:
+        """
+        Load configuration from a file, auto-detecting the format.
+
+        The format is inferred from the file extension **before** checking
+        whether the file exists, so an unsupported extension is reported
+        immediately rather than after the file is created.
+
+        Supported extensions: ``.yaml``, ``.yml``, ``.json``, ``.toml``
+        (and any extension registered via
+        :meth:`~pyconfigr.loaders.ConfigLoader.register_loader`).
+
+        Parameters
+        ----------
+        path : str | Path
+            Path to the configuration file.
+        optional : bool, optional
+            When ``True``, a missing file is silently ignored instead of
+            raising :exc:`~pyconfigr.exceptions.ConfigNotFoundError`.
+            Default is ``False``.
+
+        Returns
+        -------
+        Self
+            ``self``, for method chaining.
+
+        Raises
+        ------
+        ValueError
+            If the file extension is not supported.
+        ConfigNotFoundError
+            If the file does not exist and *optional* is ``False``.
+        ConfigLoadError
+            If the file cannot be read or parsed.
+
+        Examples
+        --------
+        ::
+
+            raw_config = (
+                RawConfigBuilder()
+                .from_file("config.yaml")
+                .from_file("local.yaml", optional=True)
+                .build_dict()
+            )
+        """
+        path = Path(path)
+
+        # Validate the extension first — gives a clear error even if the file
+        # does not yet exist, which is the common case during development.
+        ConfigLoader.validate_extension(path.suffix)
+
+        if not path.exists():
+            if optional:
+                return self
+            raise ConfigNotFoundError(f"Configuration file not found: {path}")
+
+        try:
+            data = ConfigLoader.detect_and_load(path)
+            self._merge(data)
+        except (ConfigLoadError, ConfigNotFoundError):
+            raise
+        except Exception as e:
+            raise ConfigLoadError(
+                f"Failed to load configuration from '{path}': {e}"
+            ) from e
+
+        return self
+
+    def from_env(
+        self,
+        prefix: str = "",
+        *,
+        lowercase: bool = True,
+        strip_prefix: bool = True,
+        nested: bool = True,
+    ) -> Self:
+        """
+        Load configuration from environment variables.
+
+        By default, double underscores (``__``) in variable names after
+        the prefix is stripped are interpreted as nested-key separators::
+
+            MYAPP__DATABASE__HOST=localhost  →  {"database": {"host": "localhost"}}
+
+        Single underscores are kept verbatim, so ``MYAPP_LOG_LEVEL=info``
+        becomes ``{"log_level": "info"}``.
+
+        Parameters
+        ----------
+        prefix : str, optional
+            Only load variables whose names start with this string.
+            Default is ``""`` (all variables).
+        lowercase : bool, optional
+            Keyword-only.  Convert keys to lower-case after stripping the
+            prefix.  Default is ``True``.
+        strip_prefix : bool, optional
+            Keyword-only.  Remove *prefix* from each key before storing it.
+            Default is ``True``.
+        nested : bool, optional
+            Keyword-only.  Expand ``__``-separated keys into nested dicts.
+            Default is ``True``.  Pass ``False`` to keep keys flat when
+            double underscores are intentional parts of a key name.
+
+        Returns
+        -------
+        Self
+            ``self``, for method chaining.
+
+        Examples
+        --------
+        Flat variables::
+
+            # MYAPP_DEBUG=true  MYAPP_PORT=8000
+            RawConfigBuilder().from_env("MYAPP_").build_dict()
+            # → {"debug": True, "port": 8000}
+
+        Nested variables::
+
+            # MYAPP__DATABASE__HOST=localhost  MYAPP__DATABASE__PORT=5432
+            RawConfigBuilder().from_env("MYAPP__").build_dict()
+            # → {"database": {"host": "localhost", "port": 5432}}
+
+        Opt out of nesting::
+
+            RawConfigBuilder().from_env("MYAPP__", nested=False).build_dict()
+            # Keys with __ are kept flat: {"database__host": "localhost"}
+        """
+        loader = ConfigLoader.get_loader("env")
+        data = loader(
+            prefix=prefix,
+            lowercase=lowercase,
+            strip_prefix=strip_prefix,
+            nested=nested,
+        )
+        self._merge(data)
+        return self
+
+    def from_dict(self, data: dict[str, Any]) -> Self:
+        """
+        Merge a plain dictionary into the configuration.
+
+        Parameters
+        ----------
+        data : dict[str, Any]
+            Configuration values to merge.  Nested dicts are deep-merged;
+            all other types replace existing values.
+
+        Returns
+        -------
+        Self
+            ``self``, for method chaining.
+
+        Examples
+        --------
+        ::
+
+            raw_config = (
+                RawConfigBuilder()
+                .from_dict({"debug": True, "port": 3000})
+                .build_dict()
+            )
+        """
+        self._merge(data)
+        return self
+
+    def set(self, key: str, value: Any) -> Self:
+        """
+        Set a single configuration value, optionally using dot notation.
+
+        Parameters
+        ----------
+        key : str
+            Key name.  Use dots to address nested keys:
+            ``"server.port"`` sets ``{"server": {"port": value}}``.
+        value : Any
+            Value to assign.
+
+        Returns
+        -------
+        Self
+            ``self``, for method chaining.
+
+        Raises
+        ------
+        TypeError
+            If a dot-notation segment traverses an existing value that is
+            not a dict (e.g. ``set("db.host", …)`` when ``db`` is already
+            set to a string).
+
+        Examples
+        --------
+        ::
+
+            raw_config = (
+                RawConfigBuilder()
+                .set("debug", True)
+                .set("server.port", 8080)
+                .build_dict()
+            )
+        """
+        if "." not in key:
+            self._data[key] = value
+            return self
+
+        keys = key.split(".")
+        current = self._data
+        for depth, segment in enumerate(keys[:-1]):
+            if segment not in current:
+                current[segment] = {}
+            node = current[segment]
+            if not isinstance(node, dict):
+                path_so_far = ".".join(keys[: depth + 1])
+                raise TypeError(
+                    f"Cannot set '{key}': '{path_so_far}' is already set to a "
+                    f"{type(node).__name__!r} value, not a dict.  "
+                    f"Call from_dict({{{path_so_far!r}: {{…}}}})) to replace it first."
+                )
+            current = node
+        current[keys[-1]] = value
+        return self
+
+    # ------------------------------------------------------------------
+    # Terminal / Inspection methods
+    # ------------------------------------------------------------------
+
+    def build_dict(self) -> dict[str, Any]:
+        """
+        Return the final merged configuration as a plain dictionary.
+
+        This is the terminal method for schema-free pipelines.  It returns
+        a shallow copy of the assembled data, equivalent to calling
+        :meth:`peek` but signalling intent that the pipeline is complete.
+
+        Returns
+        -------
+        dict[str, Any]
+            The assembled configuration dictionary.
+
+        Examples
+        --------
+        ::
+
+            raw_config = (
+                RawConfigBuilder()
+                .from_file("config.yaml")
+                .from_env("MYAPP_")
+                .build_dict()
+            )
+        """
+        return dict(self._data)
+
+    def peek(self) -> dict[str, Any]:
+        """
+        Return a copy of the current merged data without finalising.
+
+        Useful for debugging mid-chain to inspect what has been assembled
+        so far.
+
+        Returns
+        -------
+        dict[str, Any]
+            Snapshot of the current configuration state.
+
+        Examples
+        --------
+        ::
+
+            builder = RawConfigBuilder().from_file("app.yaml")
+            print(builder.peek())   # {'debug': False, 'port': 8000}
+            config = builder.from_env("MYAPP_").build_dict()
+        """
+        return dict(self._data)
+
+    # kept for backwards compatibility — peek() is the preferred name
+    def get_raw_data(self) -> dict[str, Any]:
+        """Return assembled data without validation.
+
+        .. deprecated:: 0.1.1
+            :meth:`get_raw_data` is deprecated and will be removed in a future
+            release.  Use :meth:`peek` instead — it is identical in behaviour::
+
+                # Before
+                builder.get_raw_data()
+
+                # After
+                builder.peek()
+        """
+        warnings.warn(
+            "get_raw_data() is deprecated and will be removed in a future release. "
+            "Use peek() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.peek()
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _merge(self, new_data: dict[str, Any]) -> None:
+        """Deep-merge *new_data* into the current state. Later wins."""
+        _deep_merge(self._data, new_data)
+
+
+class ConfigBuilder(RawConfigBuilder, Generic[T]):
+    """
+    Fluent API builder for loading, merging, and validating configuration.
+
+    Extends :class:`RawConfigBuilder` with typed Pydantic validation.
+    All pipeline methods (:meth:`from_file`, :meth:`from_env`,
+    :meth:`from_dict`, :meth:`set`, :meth:`peek`) are inherited.  Use
+    :meth:`build` to validate and return a typed Pydantic model instance.
 
     Parameters
     ----------
@@ -80,233 +435,7 @@ class ConfigBuilder(Generic[T]):
         self._data: dict[str, Any] = {}
 
     # ------------------------------------------------------------------
-    # Source methods
-    # ------------------------------------------------------------------
-
-    def from_file(self, path: str | Path, optional: bool = False) -> "ConfigBuilder[T]":
-        """
-        Load configuration from a file, auto-detecting the format.
-
-        The format is inferred from the file extension **before** checking
-        whether the file exists, so an unsupported extension is reported
-        immediately rather than after the file is created.
-
-        Supported extensions: ``.yaml``, ``.yml``, ``.json``, ``.toml``
-        (and any extension registered via
-        :meth:`~pyconfigr.loaders.ConfigLoader.register_loader`).
-
-        Parameters
-        ----------
-        path : str | Path
-            Path to the configuration file.
-        optional : bool, optional
-            When ``True``, a missing file is silently ignored instead of
-            raising :exc:`~pyconfigr.exceptions.ConfigNotFoundError`.
-            Default is ``False``.
-
-        Returns
-        -------
-        ConfigBuilder[T]
-            ``self``, for method chaining.
-
-        Raises
-        ------
-        ValueError
-            If the file extension is not supported.
-        ConfigNotFoundError
-            If the file does not exist and *optional* is ``False``.
-        ConfigLoadError
-            If the file cannot be read or parsed.
-
-        Examples
-        --------
-        ::
-
-            config = (
-                ConfigBuilder(AppConfig)
-                .from_file("config.yaml")
-                .from_file("local.yaml", optional=True)
-                .build()
-            )
-        """
-        path = Path(path)
-
-        # Validate the extension first — gives a clear error even if the file
-        # does not yet exist, which is the common case during development.
-        ConfigLoader.validate_extension(path.suffix)
-
-        if not path.exists():
-            if optional:
-                return self
-            raise ConfigNotFoundError(f"Configuration file not found: {path}")
-
-        try:
-            data = ConfigLoader.detect_and_load(path)
-            self._merge(data)
-        except (ConfigLoadError, ConfigNotFoundError):
-            raise
-        except Exception as e:
-            raise ConfigLoadError(
-                f"Failed to load configuration from '{path}': {e}"
-            ) from e
-
-        return self
-
-    def from_env(
-        self,
-        prefix: str = "",
-        *,
-        lowercase: bool = True,
-        strip_prefix: bool = True,
-        nested: bool = True,
-    ) -> "ConfigBuilder[T]":
-        """
-        Load configuration from environment variables.
-
-        By default, double underscores (``__``) in variable names after
-        the prefix is stripped are interpreted as nested-key separators::
-
-            MYAPP__DATABASE__HOST=localhost  →  {"database": {"host": "localhost"}}
-
-        Single underscores are kept verbatim, so ``MYAPP_LOG_LEVEL=info``
-        becomes ``{"log_level": "info"}``.
-
-        Parameters
-        ----------
-        prefix : str, optional
-            Only load variables whose names start with this string.
-            Default is ``""`` (all variables).
-        lowercase : bool, optional
-            Keyword-only.  Convert keys to lower-case after stripping the
-            prefix.  Default is ``True``.
-        strip_prefix : bool, optional
-            Keyword-only.  Remove *prefix* from each key before storing it.
-            Default is ``True``.
-        nested : bool, optional
-            Keyword-only.  Expand ``__``-separated keys into nested dicts.
-            Default is ``True``.  Pass ``False`` to keep keys flat when
-            double underscores are intentional parts of a key name.
-
-        Returns
-        -------
-        ConfigBuilder[T]
-            ``self``, for method chaining.
-
-        Examples
-        --------
-        Flat variables::
-
-            # MYAPP_DEBUG=true  MYAPP_PORT=8000
-            ConfigBuilder(AppConfig).from_env("MYAPP_").build()
-            # → AppConfig(debug=True, port=8000)
-
-        Nested variables::
-
-            # MYAPP__DATABASE__HOST=localhost  MYAPP__DATABASE__PORT=5432
-            ConfigBuilder(AppConfig).from_env("MYAPP__").build()
-            # → AppConfig(database=DatabaseConfig(host="localhost", port=5432))
-
-        Opt out of nesting::
-
-            ConfigBuilder(AppConfig).from_env("MYAPP__", nested=False).build()
-            # Keys with __ are kept flat: {"database__host": "localhost"}
-        """
-        loader = ConfigLoader.get_loader("env")
-        data = loader(
-            prefix=prefix,
-            lowercase=lowercase,
-            strip_prefix=strip_prefix,
-            nested=nested,
-        )
-        self._merge(data)
-        return self
-
-    def from_dict(self, data: dict[str, Any]) -> "ConfigBuilder[T]":
-        """
-        Merge a plain dictionary into the configuration.
-
-        Parameters
-        ----------
-        data : dict[str, Any]
-            Configuration values to merge.  Nested dicts are deep-merged;
-            all other types replace existing values.
-
-        Returns
-        -------
-        ConfigBuilder[T]
-            ``self``, for method chaining.
-
-        Examples
-        --------
-        ::
-
-            config = (
-                ConfigBuilder(AppConfig)
-                .from_dict({"debug": True, "port": 3000})
-                .build()
-            )
-        """
-        self._merge(data)
-        return self
-
-    def set(self, key: str, value: Any) -> "ConfigBuilder[T]":
-        """
-        Set a single configuration value, optionally using dot notation.
-
-        Parameters
-        ----------
-        key : str
-            Key name.  Use dots to address nested keys:
-            ``"server.port"`` sets ``{"server": {"port": value}}``.
-        value : Any
-            Value to assign.
-
-        Returns
-        -------
-        ConfigBuilder[T]
-            ``self``, for method chaining.
-
-        Raises
-        ------
-        TypeError
-            If a dot-notation segment traverses an existing value that is
-            not a dict (e.g. ``set("db.host", …)`` when ``db`` is already
-            set to a string).
-
-        Examples
-        --------
-        ::
-
-            config = (
-                ConfigBuilder(AppConfig)
-                .set("debug", True)
-                .set("server.port", 8080)
-                .build()
-            )
-        """
-        if "." not in key:
-            self._data[key] = value
-            return self
-
-        keys = key.split(".")
-        current = self._data
-        for depth, segment in enumerate(keys[:-1]):
-            if segment not in current:
-                current[segment] = {}
-            node = current[segment]
-            if not isinstance(node, dict):
-                path_so_far = ".".join(keys[: depth + 1])
-                raise TypeError(
-                    f"Cannot set '{key}': '{path_so_far}' is already set to a "
-                    f"{type(node).__name__!r} value, not a dict.  "
-                    f"Call from_dict({{{path_so_far!r}: {{…}}}})) to replace it first."
-                )
-            current = node
-        current[keys[-1]] = value
-        return self
-
-    # ------------------------------------------------------------------
-    # Terminal methods
+    # Terminal method
     # ------------------------------------------------------------------
 
     def build(self) -> T:
@@ -339,61 +468,9 @@ class ConfigBuilder(Generic[T]):
                 f"'{self._config_class.__name__}': {e}"
             ) from e
 
-    def peek(self) -> dict[str, Any]:
-        """
-        Return a copy of the current merged data without validating.
-
-        Useful for debugging mid-chain to inspect what has been assembled
-        so far, without triggering Pydantic validation.
-
-        Returns
-        -------
-        dict[str, Any]
-            Snapshot of the current configuration state.
-
-        Examples
-        --------
-        ::
-
-            builder = ConfigBuilder(AppConfig).from_file("app.yaml")
-            print(builder.peek())   # {'debug': False, 'port': 8000}
-            config = builder.from_env("MYAPP_").build()
-        """
-        return dict(self._data)
-
-    # kept for backwards compatibility — peek() is the preferred name
-    def get_raw_data(self) -> dict[str, Any]:
-        """Return assembled data without validation.
-
-        .. deprecated:: 0.1.1
-            :meth:`get_raw_data` is deprecated and will be removed in a future
-            release.  Use :meth:`peek` instead — it is identical in behaviour::
-
-                # Before
-                builder.get_raw_data()
-
-                # After
-                builder.peek()
-        """
-        warnings.warn(
-            "get_raw_data() is deprecated and will be removed in a future release. "
-            "Use peek() instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.peek()
-
-    # ------------------------------------------------------------------
-    # Private helpers
-    # ------------------------------------------------------------------
-
-    def _merge(self, new_data: dict[str, Any]) -> None:
-        """Deep-merge *new_data* into the current state. Later wins."""
-        _deep_merge(self._data, new_data)
-
 
 # ------------------------------------------------------------------
-# Module-level merge helper (reusable by future RawConfigBuilder)
+# Module-level merge helper (shared by RawConfigBuilder and ConfigBuilder)
 # ------------------------------------------------------------------
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ def temp_dir() -> Generator[Path, None, None]:
 def yaml_config_file(temp_dir: Path) -> Path:
     """Create temporary YAML configuration file."""
     config_content = """
-app_name: test_application
+app_name: test_application_yaml
 debug: true
 port: 9000
 server:
@@ -56,7 +56,7 @@ server:
 def json_config_file(temp_dir: Path) -> Path:
     """Create temporary JSON configuration file."""
     config_content = """{
-  "app_name": "test_application",
+  "app_name": "test_application_json",
   "debug": true,
   "port": 9000,
   "server": {
@@ -73,7 +73,7 @@ def json_config_file(temp_dir: Path) -> Path:
 def toml_config_file(temp_dir: Path) -> Path:
     """Create temporary TOML configuration file."""
     config_content = """
-app_name = "test_application"
+app_name = "test_application_toml"
 debug = true
 port = 9000
 

--- a/tests/unit/loaders/test_json.py
+++ b/tests/unit/loaders/test_json.py
@@ -24,7 +24,7 @@ class TestJSONLoader:
         loader = JSONLoader()
         config = loader(json_config_file)
 
-        assert config["app_name"] == "test_application"
+        assert config["app_name"] == "test_application_json"
         assert config["debug"] is True
         assert config["port"] == 9000
 

--- a/tests/unit/loaders/test_manager.py
+++ b/tests/unit/loaders/test_manager.py
@@ -20,7 +20,7 @@ class TestConfigLoader:
         """
         config = ConfigLoader.detect_and_load(yaml_config_file)
 
-        assert config["app_name"] == "test_application"
+        assert config["app_name"] == "test_application_yaml"
         assert config["debug"] is True
 
     def test_detect_and_load_json(self, json_config_file: Path) -> None:
@@ -33,7 +33,7 @@ class TestConfigLoader:
         """
         config = ConfigLoader.detect_and_load(json_config_file)
 
-        assert config["app_name"] == "test_application"
+        assert config["app_name"] == "test_application_json"
         assert config["debug"] is True
 
     def test_detect_and_load_toml(self, toml_config_file: Path) -> None:
@@ -46,7 +46,7 @@ class TestConfigLoader:
         """
         config = ConfigLoader.detect_and_load(toml_config_file)
 
-        assert config["app_name"] == "test_application"
+        assert config["app_name"] == "test_application_toml"
         assert config["debug"] is True
 
     def test_detect_unsupported_extension(self, temp_dir: Path) -> None:
@@ -103,6 +103,7 @@ class TestConfigLoader:
         """
         assert ConfigLoader.validate_extension("yaml") == "yaml"
         assert ConfigLoader.validate_extension("json") == "json"
+        assert ConfigLoader.validate_extension("toml") == "toml"
 
     def test_validate_extension_case_insensitive(self) -> None:
         """Test that validate_extension normalises to lower-case so that
@@ -110,6 +111,7 @@ class TestConfigLoader:
         """
         assert ConfigLoader.validate_extension(".YAML") == "yaml"
         assert ConfigLoader.validate_extension(".JSON") == "json"
+        assert ConfigLoader.validate_extension(".TOML") == "toml"
 
     def test_validate_extension_unknown_raises(self) -> None:
         """Test that validate_extension raises ValueError for an unregistered

--- a/tests/unit/loaders/test_toml.py
+++ b/tests/unit/loaders/test_toml.py
@@ -23,7 +23,7 @@ class TestTOMLLoader:
         loader = TOMLLoader()
         config = loader(toml_config_file)
 
-        assert config["app_name"] == "test_application"
+        assert config["app_name"] == "test_application_toml"
         assert config["debug"] is True
         assert config["port"] == 9000
 

--- a/tests/unit/loaders/test_yaml.py
+++ b/tests/unit/loaders/test_yaml.py
@@ -24,7 +24,7 @@ class TestYAMLLoader:
         loader = YAMLLoader()
         config = loader(yaml_config_file)
 
-        assert config["app_name"] == "test_application"
+        assert config["app_name"] == "test_application_yaml"
         assert config["debug"] is True
         assert config["port"] == 9000
         assert config["server"]["host"] == "localhost"
@@ -39,7 +39,7 @@ class TestYAMLLoader:
         """
         config = ConfigLoader.get_loader("yaml")(yaml_config_file)
 
-        assert config["app_name"] == "test_application"
+        assert config["app_name"] == "test_application_yaml"
         assert config["debug"] is True
 
     def test_yaml_file_not_found(self, temp_dir: Path) -> None:

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -1,4 +1,9 @@
-"""Test suite for ConfigBuilder."""
+"""Test suite for pyconfigr.builder — RawConfigBuilder and ConfigBuilder.
+
+This module contains unit tests for RawConfigBuilder (Parent-class) followed by
+ConfigBuilder (Child-class) smoke tests, inheritance verification, shared utilities,
+and integration tests.
+"""
 
 import os
 from pathlib import Path
@@ -7,7 +12,7 @@ from unittest import mock
 import pytest
 from tests.conftest import ComplexConfig, SimpleConfig
 
-from pyconfigr import ConfigBuilder
+from pyconfigr import ConfigBuilder, RawConfigBuilder
 from pyconfigr.builder import _deep_merge
 from pyconfigr.exceptions import (
     ConfigLoadError,
@@ -15,9 +20,649 @@ from pyconfigr.exceptions import (
     ConfigValidationError,
 )
 
+# —— RawConfigBuilder (Parent-class) Tests ————————————————————————————————————————————
+
+
+class TestRawConfigBuilder:
+    """Tests for RawConfigBuilder fluent API."""
+
+    def test_build_dict_empty_pipeline(self) -> None:
+        """Test building with no sources returns an empty dict.
+
+        Verifies that a fresh RawConfigBuilder with no sources added
+        produces an empty dictionary.
+        """
+        raw_config = RawConfigBuilder().build_dict()
+
+        assert isinstance(raw_config, dict)
+        assert raw_config == {}
+
+    def test_build_dict_from_dict(self) -> None:
+        """Test building simple configuration from a plain dictionary.
+
+        Verifies that RawConfigBuilder produces a plain dictionary
+        without requiring a Pydantic schema.
+        """
+        raw_config = (
+            RawConfigBuilder().from_dict({"debug": True, "port": 3000}).build_dict()
+        )
+
+        assert isinstance(raw_config, dict)
+        assert raw_config == {"debug": True, "port": 3000}
+
+    def test_from_file_yaml(self, yaml_config_file: Path) -> None:
+        """Test loading configuration from a YAML file.
+
+        Parameters
+        ----------
+        yaml_config_file : Path
+            Fixture providing a temporary YAML config file.
+        """
+        raw_config = RawConfigBuilder().from_file(yaml_config_file).build_dict()
+
+        assert raw_config["app_name"] == "test_application_yaml"
+        assert raw_config["debug"] is True
+        assert raw_config["port"] == 9000
+
+    def test_from_file_json(self, json_config_file: Path) -> None:
+        """Test loading configuration from JSON file.
+
+        Parameters
+        ----------
+        json_config_file : Path
+            Fixture providing a temporary JSON config file.
+        """
+        raw_config = RawConfigBuilder().from_file(json_config_file).build_dict()
+
+        assert raw_config["app_name"] == "test_application_json"
+        assert raw_config["debug"] is True
+
+    def test_from_file_toml(self, toml_config_file: Path) -> None:
+        """Test loading configuration from a TOML file.
+
+        Parameters
+        ----------
+        toml_config_file : Path
+            Fixture providing a temporary TOML config file.
+        """
+        raw_config = RawConfigBuilder().from_file(toml_config_file).build_dict()
+
+        assert raw_config["app_name"] == "test_application_toml"
+        assert raw_config["debug"] is True
+
+    def test_from_file_optional_missing(self, temp_dir: Path) -> None:
+        """Test optional file parameter with missing file.
+
+        Verifies that missing optional files do not raise an error
+        and configuration continues with empty state.
+
+        Parameters
+        ----------
+        temp_dir : Path
+            Fixture providing a temporary directory.
+        """
+        nonexistent = temp_dir / "missing.yaml"
+
+        raw_config = (
+            RawConfigBuilder().from_file(nonexistent, optional=True).build_dict()
+        )
+
+        assert raw_config == {}
+
+    def test_from_file_required_missing(self, temp_dir: Path) -> None:
+        """Test error when required file is missing.
+
+        Verifies that RawConfigBuilder raises ConfigNotFoundError when
+        a required configuration file is missing.
+
+        Parameters
+        ----------
+        temp_dir : Path
+            Fixture providing a temporary directory.
+        """
+        nonexistent = temp_dir / "missing.yaml"
+
+        with pytest.raises(ConfigNotFoundError):
+            RawConfigBuilder().from_file(nonexistent)
+
+    def test_from_env(self) -> None:
+        """Test loading from environment variables.
+
+        Sets environment variables and verifies they are loaded and
+        properly type-parsed by the builder.
+        """
+        os.environ["RAW_APP_NAME"] = "env_app"
+        os.environ["RAW_DEBUG"] = "true"
+        os.environ["RAW_PORT"] = "3000"
+
+        try:
+            raw_config = RawConfigBuilder().from_env(prefix="RAW_").build_dict()
+
+            assert raw_config["app_name"] == "env_app"
+            assert raw_config["debug"] is True
+            assert raw_config["port"] == 3000
+        finally:
+            for key in ["RAW_APP_NAME", "RAW_DEBUG", "RAW_PORT"]:
+                del os.environ[key]
+
+    def test_from_dict(self) -> None:
+        """Test loading from dictionary.
+
+        Verifies that RawConfigBuilder can load configuration from
+        a Python dictionary.
+        """
+        raw_config = (
+            RawConfigBuilder()
+            .from_dict({"app_name": "dict_app", "port": 5000})
+            .build_dict()
+        )
+
+        assert raw_config["app_name"] == "dict_app"
+        assert raw_config["port"] == 5000
+
+    def test_from_dict_empty(self) -> None:
+        """Test loading an empty dictionary.
+
+        Verifies that merging an empty dict is a no-op and does not disturb
+        existing state.
+        """
+        raw_config = (
+            RawConfigBuilder().from_dict({"port": 3000}).from_dict({}).build_dict()
+        )
+
+        assert raw_config == {"port": 3000}
+
+    def test_set_value(self) -> None:
+        """Test setting individual configuration values.
+
+        Verifies that RawConfigBuilder.set() can set individual
+        configuration values.
+        """
+        raw_config = (
+            RawConfigBuilder().set("app_name", "set_app").set("port", 7000).build_dict()
+        )
+
+        assert raw_config["app_name"] == "set_app"
+        assert raw_config["port"] == 7000
+
+    def test_set_nested_value(self) -> None:
+        """Test setting nested configuration values.
+
+        Verifies that RawConfigBuilder.set() supports dot notation
+        for setting nested configuration values.
+        """
+        raw_config = (
+            RawConfigBuilder()
+            .set("server.host", "example.com")
+            .set("server.port", 5432)
+            .build_dict()
+        )
+
+        assert raw_config["server"]["host"] == "example.com"
+        assert raw_config["server"]["port"] == 5432
+
+    def test_multiple_sources_priority(
+        self, yaml_config_file: Path, json_config_file: Path
+    ) -> None:
+        """Test priority merging of multiple sources.
+
+        Verifies that when loading from multiple sources, later sources
+        override earlier ones (YAML → JSON → dict).
+
+        Parameters
+        ----------
+        yaml_config_file : Path
+            Fixture providing a temporary YAML config file.
+        json_config_file : Path
+            Fixture providing a temporary JSON config file.
+        """
+        raw_config = (
+            RawConfigBuilder()
+            .from_file(yaml_config_file)
+            .from_file(json_config_file)
+            .from_dict({"port": 7000})
+            .build_dict()
+        )
+
+        assert raw_config["app_name"] == "test_application_json"
+        assert raw_config["port"] == 7000
+
+    def test_full_priority_chain(self, yaml_config_file: Path) -> None:
+        """Test the full file → env → dict → set() priority chain.
+
+        Each source overrides the one before it.  The YAML fixture provides
+        ``app_name``, ``debug`` and ``port``; env overrides ``debug``;
+        dict overrides ``port``; and set() overrides ``app_name``.
+
+        Parameters
+        ----------
+        yaml_config_file : Path
+            Fixture providing a temporary YAML config file.
+        """
+        os.environ["PRIORITY_DEBUG"] = "false"
+
+        try:
+            raw_config = (
+                RawConfigBuilder()
+                .from_file(yaml_config_file)
+                .from_env(prefix="PRIORITY_")
+                .from_dict({"port": 4000})
+                .set("app_name", "chain_override_app")
+                .build_dict()
+            )
+
+            assert raw_config["app_name"] == "chain_override_app"
+            assert raw_config["debug"] is False
+            assert raw_config["port"] == 4000
+        finally:
+            del os.environ["PRIORITY_DEBUG"]
+
+    def test_get_raw_data(self, yaml_config_file: Path) -> None:
+        """Test that get_raw_data() emits DeprecationWarning and returns
+        the same result as peek().
+
+        ``get_raw_data()`` is a deprecated alias for ``peek()`` as of v0.1.1.
+        This test verifies both that the warning is emitted and that the
+        return value equals peek().
+
+        Parameters
+        ----------
+        yaml_config_file : Path
+            Fixture providing a temporary YAML config file.
+        """
+        raw_config_builder = RawConfigBuilder().from_file(yaml_config_file)
+        raw_peeked = raw_config_builder.peek()
+
+        with pytest.warns(DeprecationWarning, match="get_raw_data\\(\\) is deprecated"):
+            raw_data = raw_config_builder.get_raw_data()
+
+        assert isinstance(raw_data, dict)
+        assert raw_data["app_name"] == "test_application_yaml"
+        assert raw_data["debug"] is True
+        assert raw_data == raw_peeked  # values must be equal
+        assert raw_data is not raw_peeked  # must be a copy, not the same reference
+
+    def test_fluent_api_chaining(self, yaml_config_file: Path) -> None:
+        """Test fluent API method chaining.
+
+        Verifies that RawConfigBuilder methods return self for method
+        chaining in a fluent API style.
+
+        Parameters
+        ----------
+        yaml_config_file : Path
+            Fixture providing a temporary YAML config file.
+        """
+        raw_config = (
+            RawConfigBuilder()
+            .from_file(yaml_config_file)
+            .set("port", 8888)
+            .from_dict({"debug": False})
+            .build_dict()
+        )
+
+        assert raw_config["app_name"] == "test_application_yaml"
+        assert raw_config["port"] == 8888
+        assert raw_config["debug"] is False
+
+
+class TestRawConfigBuilderFromFile:
+    """Tests for from_file extension and existence ordering."""
+
+    def test_from_file_validates_extension_before_existence(
+        self, temp_dir: Path
+    ) -> None:
+        """Test that extension is validated before checking file existence.
+
+        A file with an unsupported extension that also does not exist should
+        raise ValueError (unsupported extension), not ConfigNotFoundError
+        (file missing).  The extension error is more actionable at development
+        time.
+
+        Parameters
+        ----------
+        temp_dir : Path
+            Fixture providing a temporary directory.
+        """
+        missing_with_bad_ext = temp_dir / "config.xyz"
+        # File does NOT exist — but extension is bad, so ValueError must come first
+
+        with pytest.raises(ValueError, match="Unsupported file format"):
+            RawConfigBuilder().from_file(missing_with_bad_ext)
+
+    def test_from_file_optional_bad_extension_still_raises(
+        self, temp_dir: Path
+    ) -> None:
+        """Test that optional=True does not suppress unsupported-extension errors.
+
+        ``optional`` silences missing-file errors only.  An unsupported extension
+        is a programmer error and must always raise regardless of ``optional``.
+
+        Parameters
+        ----------
+        temp_dir : Path
+            Fixture providing a temporary directory.
+        """
+        missing_with_bad_ext = temp_dir / "config.xyz"
+
+        with pytest.raises(ValueError, match="Unsupported file format"):
+            RawConfigBuilder().from_file(missing_with_bad_ext, optional=True)
+
+
+class TestRawConfigBuilderExceptionHandling:
+    """Tests exception handling and edge cases in RawConfigBuilder."""
+
+    def test_from_file_with_unsupported_extension(self, temp_dir: Path) -> None:
+        """Test error when file has unsupported extension.
+
+        Extension is validated before existence check, so this raises
+        ValueError even when the file exists.
+
+        Parameters
+        ----------
+        temp_dir : Path
+            Fixture providing a temporary directory.
+        """
+        unsupported_file = temp_dir / "config.unknown"
+        unsupported_file.write_text("some content")
+
+        raw_config_builder = RawConfigBuilder()
+
+        with pytest.raises(ValueError, match="Unsupported file format"):
+            raw_config_builder.from_file(unsupported_file)
+
+    def test_from_file_generic_exception_wrapping(self, temp_dir: Path) -> None:
+        """Test that generic exceptions are wrapped in ConfigLoadError.
+
+        Parameters
+        ----------
+        temp_dir : Path
+            Fixture providing a temporary directory.
+        """
+        config_file = temp_dir / "config.json"
+        config_file.write_text('{"debug": true}')
+
+        raw_config_builder = RawConfigBuilder()
+
+        with mock.patch("pyconfigr.builder.ConfigLoader.detect_and_load") as mock_load:
+            mock_load.side_effect = RuntimeError("Unexpected error")
+
+            with pytest.raises(ConfigLoadError, match="Failed to load configuration"):
+                raw_config_builder.from_file(config_file)
+
+    def test_from_file_propagates_value_error(self, temp_dir: Path) -> None:
+        """Test that ValueError from unsupported extension is propagated.
+
+        Parameters
+        ----------
+        temp_dir : Path
+            Fixture providing a temporary directory.
+        """
+        unsupported_file = temp_dir / "config.xyz"
+        unsupported_file.write_text("content")
+
+        raw_config_builder = RawConfigBuilder()
+
+        with pytest.raises(ValueError):
+            raw_config_builder.from_file(unsupported_file)
+
+    def test_from_file_propagates_config_load_error(self, temp_dir: Path) -> None:
+        """Test that ConfigLoadError from loaders is propagated.
+
+        Parameters
+        ----------
+        temp_dir : Path
+            Fixture providing a temporary directory.
+        """
+        config_file = temp_dir / "config.json"
+        config_file.write_text('{"debug": true}')
+
+        raw_config_builder = RawConfigBuilder()
+
+        with mock.patch("pyconfigr.builder.ConfigLoader.detect_and_load") as mock_load:
+            mock_load.side_effect = ConfigLoadError("Parse error")
+
+            with pytest.raises(ConfigLoadError, match="Parse error"):
+                raw_config_builder.from_file(config_file)
+
+
+class TestRawConfigBuilderSetMethod:
+    """Tests set method with dot notation."""
+
+    def test_set_simple_key(self) -> None:
+        """Test setting a simple key."""
+        raw_config_builder = RawConfigBuilder()
+        raw_config_builder.set("app_name", "my_app")
+
+        raw_peeked = raw_config_builder.peek()
+        assert raw_peeked["app_name"] == "my_app"
+
+    def test_set_nested_key_with_dot_notation(self) -> None:
+        """Test setting nested key using dot notation."""
+        raw_config_builder = RawConfigBuilder()
+        raw_config_builder.set("database.host", "localhost")
+        raw_config_builder.set("database.port", 5432)
+
+        raw_peeked = raw_config_builder.peek()
+        assert raw_peeked["database"]["host"] == "localhost"
+        assert raw_peeked["database"]["port"] == 5432
+
+    def test_set_deeply_nested_key(self) -> None:
+        """Test setting a deeply nested key."""
+        raw_config_builder = RawConfigBuilder()
+        raw_config_builder.set("app.db.connection.host", "db.example.com")
+
+        raw_peeked = raw_config_builder.peek()
+        assert raw_peeked["app"]["db"]["connection"]["host"] == "db.example.com"
+
+    def test_set_overwrites_existing_key(self) -> None:
+        """Test that set overwrites existing values."""
+        raw_config_builder = RawConfigBuilder()
+        raw_config_builder.set("debug", False)
+        raw_config_builder.set("debug", True)
+
+        raw_peeked = raw_config_builder.peek()
+        assert raw_peeked["debug"] is True
+
+    def test_set_method_returns_self(self) -> None:
+        """Test that set method returns self for fluent chaining."""
+        raw_config_builder = RawConfigBuilder()
+        raw_config = raw_config_builder.set("key", "value")
+
+        assert raw_config is raw_config_builder
+
+    def test_set_raises_type_error_on_scalar_intermediate(self) -> None:
+        """Test that set() raises TypeError with a clear message
+        when a dot-notation path segment exists but is not a dict.
+
+        The error message must include:
+        - the full requested key path
+        - the name of the offending intermediate segment
+        - the actual type that was found
+        """
+        raw_config_builder = RawConfigBuilder()
+        raw_config_builder._data = {"database": "not_a_dict"}
+
+        with pytest.raises(TypeError) as exc_info:
+            raw_config_builder.set("database.host", "localhost")
+
+        message = str(exc_info.value)
+        assert "database.host" in message
+        assert "database" in message
+        assert "str" in message
+
+    def test_set_raises_type_error_on_deeply_nested_scalar(self) -> None:
+        """Test TypeError is raised at the correct depth for deep paths."""
+        raw_config_builder = RawConfigBuilder()
+        raw_config_builder._data = {"a": {"b": "scalar"}}
+
+        with pytest.raises(TypeError) as exc_info:
+            raw_config_builder.set("a.b.c", "value")
+
+        message = str(exc_info.value)
+        assert "a.b.c" in message
+        assert "a.b" in message
+        assert "str" in message
+
+
+class TestRawConfigBuilderFluentAPI:
+    """Test fluent API chaining."""
+
+    def test_chaining_all_methods(self, temp_dir: Path) -> None:
+        """Test chaining multiple methods.
+
+        Parameters
+        ----------
+        temp_dir : Path
+            Fixture providing a temporary directory.
+        """
+        config_file = temp_dir / "config.json"
+        config_file.write_text('{"app_name": "file_app"}')
+
+        os.environ["FLUENT_RAW_DEBUG"] = "true"
+
+        try:
+            raw_config = (
+                RawConfigBuilder()
+                .from_file(config_file)
+                .from_env(prefix="FLUENT_RAW_")
+                .set("port", 7000)
+                .build_dict()
+            )
+
+            assert raw_config["app_name"] == "file_app"
+            assert raw_config["debug"] is True
+            assert raw_config["port"] == 7000
+        finally:
+            del os.environ["FLUENT_RAW_DEBUG"]
+
+    def test_multiple_from_dict_calls(self) -> None:
+        """Test multiple from_dict calls with proper priority."""
+        raw_config = (
+            RawConfigBuilder()
+            .from_dict({"debug": False, "port": 8000})
+            .from_dict({"debug": True})
+            .from_dict({"port": 9000})
+            .build_dict()
+        )
+
+        assert raw_config["debug"] is True
+        assert raw_config["port"] == 9000
+
+    def test_get_raw_data(self, temp_dir: Path) -> None:
+        """Test get_raw_data emits DeprecationWarning and returns a copy.
+
+        Verifies that:
+        - ``DeprecationWarning`` is emitted on every call
+        - each call returns an independent copy (mutations do not bleed)
+        - the returned data matches the builder's internal state
+
+        Parameters
+        ----------
+        temp_dir : Path
+            Fixture providing a temporary directory.
+        """
+        config_file = temp_dir / "config.json"
+        config_file.write_text('{"port": 3000}')
+
+        raw_config_builder = RawConfigBuilder().from_file(config_file)
+
+        with pytest.warns(DeprecationWarning, match="get_raw_data\\(\\) is deprecated"):
+            raw1 = raw_config_builder.get_raw_data()
+
+        with pytest.warns(DeprecationWarning):
+            raw2 = raw_config_builder.get_raw_data()
+
+        assert raw1 == raw2
+        assert raw1 is not raw2
+
+        raw1["port"] = 9999
+
+        with pytest.warns(DeprecationWarning):
+            raw3 = raw_config_builder.get_raw_data()
+
+        assert raw3["port"] == 3000
+
+    def test_peek_returns_copy(self, temp_dir: Path) -> None:
+        """Test that peek() returns a copy equal to get_raw_data().
+
+        ``peek()`` is the preferred name; ``get_raw_data()`` is its
+        deprecated alias.  Both must return equal, independent copies.
+
+        Parameters
+        ----------
+        temp_dir : Path
+            Fixture providing a temporary directory.
+        """
+        config_file = temp_dir / "config.json"
+        config_file.write_text('{"port": 4000}')
+
+        raw_config_builder = RawConfigBuilder().from_file(config_file)
+
+        raw_peeked = raw_config_builder.peek()
+
+        with pytest.warns(DeprecationWarning):
+            raw = raw_config_builder.get_raw_data()
+
+        assert raw_peeked == raw
+        assert raw_peeked is not raw
+
+    def test_peek_is_nondestructive(self, temp_dir: Path) -> None:
+        """Test that mutating the dict returned by peek() does not affect
+        the builder's internal state.
+
+        Parameters
+        ----------
+        temp_dir : Path
+            Fixture providing a temporary directory.
+        """
+        config_file = temp_dir / "config.json"
+        config_file.write_text('{"port": 5000}')
+
+        raw_config_builder = RawConfigBuilder().from_file(config_file)
+
+        snapshot = raw_config_builder.peek()
+        snapshot["port"] = 99999
+
+        assert raw_config_builder.peek()["port"] == 5000
+
+    def test_build_dict_returns_copy(self) -> None:
+        """Test that build_dict() returns a copy, not a reference.
+
+        Mutating the returned dictionary must not affect the
+        builder's internal state, allowing build_dict() to be called
+        multiple times with consistent results.
+        """
+        raw_config_builder = RawConfigBuilder().from_dict({"port": 6000})
+
+        first = raw_config_builder.build_dict()
+        first["port"] = 99999
+
+        second = raw_config_builder.build_dict()
+
+        assert second["port"] == 6000
+        assert first is not second
+
+    def test_build_dict_called_multiple_times_returns_consistent_copies(self) -> None:
+        """Test that build_dict() produces equal results on repeated call.
+
+        The internal method must be independent — calling it multiple
+        times without changing the pipeline must return equal dictionaries.
+        """
+        raw_config_builder = RawConfigBuilder().from_dict({"debug": True, "port": 3000})
+
+        first = raw_config_builder.build_dict()
+        second = raw_config_builder.build_dict()
+
+        assert first == second
+        assert first is not second
+
+
+# —— ConfigBuilder (Child-class) Tests ————————————————————————————————————————————
+
 
 class TestConfigBuilder:
-    """Tests for ConfigBuilder fluent API."""
+    """Smoke tests for ConfigBuilder — inherited pipeline → build()."""
 
     def test_build_basic_config(self) -> None:
         """Test building simple configuration.
@@ -43,7 +688,7 @@ class TestConfigBuilder:
             ConfigBuilder(ComplexConfig).from_file(yaml_config_file).build()
         )
 
-        assert config.app_name == "test_application"
+        assert config.app_name == "test_application_yaml"
         assert config.debug is True
         assert config.port == 9000
 
@@ -59,7 +704,7 @@ class TestConfigBuilder:
             ConfigBuilder(ComplexConfig).from_file(json_config_file).build()
         )
 
-        assert config.app_name == "test_application"
+        assert config.app_name == "test_application_json"
         assert config.debug is True
 
     def test_from_file_optional_missing(self, temp_dir: Path) -> None:
@@ -80,22 +725,6 @@ class TestConfigBuilder:
         )
 
         assert config.app_name == "test_app"
-
-    def test_from_file_required_missing(self, temp_dir: Path) -> None:
-        """Test error when required file is missing.
-
-        Verifies that ConfigBuilder raises ConfigNotFoundError when
-        a required configuration file is missing.
-
-        Parameters
-        ----------
-        temp_dir : Path
-            Fixture providing a temporary directory.
-        """
-        nonexistent = temp_dir / "missing.yaml"
-
-        with pytest.raises(ConfigNotFoundError):
-            ConfigBuilder(SimpleConfig).from_file(nonexistent).build()
 
     def test_from_env(self) -> None:
         """Test loading from environment variables.
@@ -191,96 +820,8 @@ class TestConfigBuilder:
             .build()
         )
 
-        assert config.app_name == "test_application"
+        assert config.app_name == "test_application_json"
         assert config.port == 7000
-
-    def test_get_raw_data(self, yaml_config_file: Path) -> None:
-        """Test that get_raw_data() emits DeprecationWarning and returns
-        the same result as peek().
-
-        ``get_raw_data()`` is a deprecated alias for ``peek()`` as of v0.1.1.
-        This test verifies both that the warning is emitted and that the
-        return value is correct.
-
-        Parameters
-        ----------
-        yaml_config_file : Path
-            Fixture providing a temporary YAML config file.
-        """
-        builder = ConfigBuilder(ComplexConfig).from_file(yaml_config_file)
-
-        with pytest.warns(DeprecationWarning, match="get_raw_data\\(\\) is deprecated"):
-            raw_data = builder.get_raw_data()
-
-        assert isinstance(raw_data, dict)
-        assert raw_data["app_name"] == "test_application"
-        assert raw_data["debug"] is True
-
-    def test_fluent_api_chaining(self, yaml_config_file: Path) -> None:
-        """Test fluent API method chaining.
-
-        Verifies that ConfigBuilder methods return self for method
-        chaining in a fluent API style.
-
-        Parameters
-        ----------
-        yaml_config_file : Path
-            Fixture providing a temporary YAML config file.
-        """
-        config: ComplexConfig = (
-            ConfigBuilder(ComplexConfig)
-            .from_file(yaml_config_file)
-            .set("port", 8888)
-            .from_dict({"debug": False})
-            .build()
-        )
-
-        assert config.app_name == "test_application"
-        assert config.port == 8888
-        assert config.debug is False
-
-
-class TestConfigBuilderFromFile:
-    """Tests for from_file extension and existence ordering."""
-
-    def test_from_file_validates_extension_before_existence(
-        self, temp_dir: Path
-    ) -> None:
-        """Test that extension is validated before checking file existence.
-
-        A file with an unsupported extension that also does not exist should
-        raise ValueError (unsupported extension), not ConfigNotFoundError
-        (file missing).  The extension error is more actionable at development
-        time.
-
-        Parameters
-        ----------
-        temp_dir : Path
-            Fixture providing a temporary directory.
-        """
-        missing_with_bad_ext = temp_dir / "config.xyz"
-        # File does NOT exist — but extension is bad, so ValueError must come first
-
-        with pytest.raises(ValueError, match="Unsupported file format"):
-            ConfigBuilder(SimpleConfig).from_file(missing_with_bad_ext)
-
-    def test_from_file_optional_bad_extension_still_raises(
-        self, temp_dir: Path
-    ) -> None:
-        """Test that optional=True does not suppress unsupported-extension errors.
-
-        ``optional`` silences missing-file errors only.  An unsupported extension
-        is a programmer error and must always raise regardless of ``optional``.
-
-        Parameters
-        ----------
-        temp_dir : Path
-            Fixture providing a temporary directory.
-        """
-        missing_with_bad_ext = temp_dir / "config.xyz"
-
-        with pytest.raises(ValueError, match="Unsupported file format"):
-            ConfigBuilder(SimpleConfig).from_file(missing_with_bad_ext, optional=True)
 
 
 class TestIntegration:
@@ -313,7 +854,7 @@ class TestIntegration:
                 .build()
             )
 
-            assert config.app_name == "test_application"
+            assert config.app_name == "test_application_json"
             assert config.port == 6000
             assert config.debug is False
         finally:
@@ -345,46 +886,8 @@ class TestIntegration:
         assert yaml_config == yml_config
 
 
-class TestConfigBuilderExceptionHandling:
-    """Test exception handling and edge cases in ConfigBuilder."""
-
-    def test_from_file_with_unsupported_extension(self, temp_dir: Path) -> None:
-        """Test error when file has unsupported extension.
-
-        Extension is validated before existence check, so this raises
-        ValueError even when the file exists.
-
-        Parameters
-        ----------
-        temp_dir : Path
-            Fixture providing a temporary directory.
-        """
-        unsupported_file = temp_dir / "config.unknown"
-        unsupported_file.write_text("some content")
-
-        builder = ConfigBuilder(SimpleConfig)
-
-        with pytest.raises(ValueError, match="Unsupported file format"):
-            builder.from_file(unsupported_file).build()
-
-    def test_from_file_generic_exception_wrapping(self, temp_dir: Path) -> None:
-        """Test that generic exceptions are wrapped in ConfigLoadError.
-
-        Parameters
-        ----------
-        temp_dir : Path
-            Fixture providing a temporary directory.
-        """
-        config_file = temp_dir / "config.json"
-        config_file.write_text('{"debug": true}')
-
-        builder = ConfigBuilder(SimpleConfig)
-
-        with mock.patch("pyconfigr.builder.ConfigLoader.detect_and_load") as mock_load:
-            mock_load.side_effect = RuntimeError("Unexpected error")
-
-            with pytest.raises(ConfigLoadError, match="Failed to load configuration"):
-                builder.from_file(config_file).build()
+class TestConfigBuilderValidation:
+    """Test for Pydantic validation — ConfigBuilder-specific behavior."""
 
     def test_validation_error_on_invalid_type(self) -> None:
         """Test validation error when config has invalid types."""
@@ -395,48 +898,16 @@ class TestConfigBuilderExceptionHandling:
         ):
             builder.from_dict({"port": "not_a_number"}).build()
 
-    def test_from_file_propagates_value_error(self, temp_dir: Path) -> None:
-        """Test that ValueError from unsupported extension is propagated.
 
-        Parameters
-        ----------
-        temp_dir : Path
-            Fixture providing a temporary directory.
-        """
-        unsupported_file = temp_dir / "config.xyz"
-        unsupported_file.write_text("content")
-
-        builder = ConfigBuilder(SimpleConfig)
-
-        with pytest.raises(ValueError):
-            builder.from_file(unsupported_file).build()
-
-    def test_from_file_propagates_config_load_error(self, temp_dir: Path) -> None:
-        """Test that ConfigLoadError from loaders is propagated.
-
-        Parameters
-        ----------
-        temp_dir : Path
-            Fixture providing a temporary directory.
-        """
-        config_file = temp_dir / "config.json"
-        config_file.write_text('{"debug": true}')
-
-        builder = ConfigBuilder(SimpleConfig)
-
-        with mock.patch("pyconfigr.builder.ConfigLoader.detect_and_load") as mock_load:
-            mock_load.side_effect = ConfigLoadError("Parse error")
-
-            with pytest.raises(ConfigLoadError, match="Parse error"):
-                builder.from_file(config_file).build()
+# —— Shared Utilities Tests ————————————————————————————————————————————
 
 
-class TestConfigBuilderDeepMerge:
+class TestDeepMerge:
     """Test deep merge functionality.
 
     ``_deep_merge`` is a module-level function in ``pyconfigr.builder``.
     Tests import it directly to verify its logic in isolation, independently
-    of ConfigBuilder construction.
+    of any builder class.
     """
 
     def test_deep_merge_nested_dicts(self) -> None:
@@ -503,201 +974,60 @@ class TestConfigBuilderDeepMerge:
         assert target == {"x": {"y": 1}}
 
 
-class TestConfigBuilderSetMethod:
-    """Test set method with dot notation."""
+# —— Inheritance Tests ————————————————————————————————————————————
 
-    def test_set_simple_key(self) -> None:
-        """Test setting a simple key."""
-        builder = ConfigBuilder(SimpleConfig)
-        builder.set("app_name", "my_app")
 
-        raw = builder.peek()
-        assert raw["app_name"] == "my_app"
+class TestBuilderInheritance:
+    """Test verifying ConfigBuilder inheritance from RawConfigBuilder."""
 
-    def test_set_nested_key_with_dot_notation(self) -> None:
-        """Test setting nested key using dot notation."""
-        builder = ConfigBuilder(SimpleConfig)
-        builder.set("database.host", "localhost")
-        builder.set("database.port", 5432)
+    def test_config_builder_is_instance_of_raw_config_builder(self) -> None:
+        """Test that ConfigBuilder is a subclass of RawConfigBuilder.
 
-        raw = builder.peek()
-        assert raw["database"]["host"] == "localhost"
-        assert raw["database"]["port"] == 5432
-
-    def test_set_deeply_nested_key(self) -> None:
-        """Test setting deeply nested key."""
-        builder = ConfigBuilder(SimpleConfig)
-        builder.set("app.db.connection.host", "db.example.com")
-
-        raw = builder.peek()
-        assert raw["app"]["db"]["connection"]["host"] == "db.example.com"
-
-    def test_set_overwrites_existing_value(self) -> None:
-        """Test that set overwrites existing values."""
-        builder = ConfigBuilder(SimpleConfig)
-        builder.set("debug", False)
-        builder.set("debug", True)
-
-        raw = builder.peek()
-        assert raw["debug"] is True
-
-    def test_set_method_returns_self(self) -> None:
-        """Test that set method returns self for chaining."""
-        builder = ConfigBuilder(SimpleConfig)
-        result = builder.set("key", "value")
-
-        assert result is builder
-
-    def test_set_raises_type_error_on_scalar_intermediate(self) -> None:
-        """Test that set() raises TypeError with a clear message when a
-        dot-notation path segment exists but is not a dict.
-
-        The error message must include:
-        - the full requested key path
-        - the name of the offending intermediate segment
-        - the actual type that was found
+        Verifies the inheritance relationship established in v0.2.0
+        where ConfigBuilder extends RawConfigBuilder.
         """
-        builder = ConfigBuilder(SimpleConfig)
-        builder._data = {"database": "not-a-dict"}
+        config_builder = ConfigBuilder(SimpleConfig)
 
-        with pytest.raises(TypeError) as exc_info:
-            builder.set("database.host", "localhost")
+        assert isinstance(config_builder, RawConfigBuilder)
 
-        message = str(exc_info.value)
-        assert "database.host" in message  # full key path
-        assert "database" in message  # offending segment
-        assert "str" in message  # actual type found
+    def test_config_builder_inherits_all_pipeline_methods(
+        self, yaml_config_file: Path
+    ) -> None:
+        """Test that ConfigBuilder inherits all pipeline methods from RawConfigBuilder.
 
-    def test_set_raises_type_error_on_deeply_nested_scalar(self) -> None:
-        """Test TypeError is raised at the correct depth for deep paths.
+        All pipeline methods must be callable on ConfigBuilder and
+        return self for fluent chaining.
 
         Parameters
         ----------
-        None
+        yaml_config_file : Path
+            Fixture providing a temporary YAML config file.
         """
-        builder = ConfigBuilder(SimpleConfig)
-        builder._data = {"a": {"b": "scalar"}}
+        config_builder = ConfigBuilder(SimpleConfig)
 
-        with pytest.raises(TypeError) as exc_info:
-            builder.set("a.b.c", "value")
+        assert config_builder.from_file(yaml_config_file) is config_builder
+        assert config_builder.from_dict({"port": 7000}) is config_builder
+        assert config_builder.set("debug", False) is config_builder
 
-        message = str(exc_info.value)
-        assert "a.b.c" in message
-        assert "a.b" in message
-        assert "str" in message
+        peeked = config_builder.peek()
+        assert isinstance(peeked, dict)
+        assert peeked["app_name"] == "test_application_yaml"
+        assert peeked["port"] == 7000
+        assert peeked["debug"] is False
 
+    def test_build_dict_available_on_config_builder(self) -> None:
+        """Test that build_dict() is callable on ConfigBuilder.
 
-class TestConfigBuilderFluentAPI:
-    """Test fluent API chaining."""
-
-    def test_chaining_all_methods(self, temp_dir: Path) -> None:
-        """Test chaining multiple methods."""
-        config_file = temp_dir / "config.json"
-        config_file.write_text('{"app_name": "file_app"}')
-
-        os.environ["FLUENT_DEBUG"] = "true"
-
-        try:
-            config: SimpleConfig = (
-                ConfigBuilder(SimpleConfig)
-                .from_file(config_file)
-                .from_env(prefix="FLUENT_")
-                .set("port", 7000)
-                .build()
-            )
-
-            assert config.app_name == "file_app"
-            assert config.debug is True
-            assert config.port == 7000
-        finally:
-            del os.environ["FLUENT_DEBUG"]
-
-    def test_multiple_from_dict_calls(self) -> None:
-        """Test multiple from_dict calls with proper priority."""
-        builder = ConfigBuilder(SimpleConfig)
-        config: SimpleConfig = (
-            builder.from_dict({"debug": False, "port": 8000})
-            .from_dict({"debug": True})
-            .from_dict({"port": 9000})
-            .build()
+        ConfigBuilder inherits build_dict() from rawConfigBuilder,
+        allowing users to get a plain dictionary even when a schema
+        is available.
+        """
+        config_builder = (
+            ConfigBuilder(SimpleConfig)
+            .from_dict({"app_name": "inherited", "port": 5000})
+            .build_dict()
         )
 
-        assert config.debug is True
-        assert config.port == 9000
-
-    def test_get_raw_data(self, temp_dir: Path) -> None:
-        """Test get_raw_data emits DeprecationWarning and returns a copy.
-
-        Verifies that:
-        - ``DeprecationWarning`` is emitted on every call
-        - each call returns an independent copy (mutations do not bleed)
-        - the returned data matches the builder's internal state
-
-        Parameters
-        ----------
-        temp_dir : Path
-            Fixture providing a temporary directory.
-        """
-        config_file = temp_dir / "config.json"
-        config_file.write_text('{"port": 3000}')
-
-        builder = ConfigBuilder(SimpleConfig).from_file(config_file)
-
-        with pytest.warns(DeprecationWarning, match="get_raw_data\\(\\) is deprecated"):
-            raw1 = builder.get_raw_data()
-
-        with pytest.warns(DeprecationWarning):
-            raw2 = builder.get_raw_data()
-
-        assert raw1 == raw2
-        assert raw1 is not raw2
-
-        raw1["port"] = 9999
-
-        with pytest.warns(DeprecationWarning):
-            raw3 = builder.get_raw_data()
-
-        assert raw3["port"] == 3000
-
-    def test_peek_returns_copy(self, temp_dir: Path) -> None:
-        """Test that peek() returns a copy equal to get_raw_data().
-
-        ``peek()`` is the preferred name; ``get_raw_data()`` is its
-        deprecated alias.  Both must return equal, independent copies.
-
-        Parameters
-        ----------
-        temp_dir : Path
-            Fixture providing a temporary directory.
-        """
-        config_file = temp_dir / "config.json"
-        config_file.write_text('{"port": 4000}')
-
-        builder = ConfigBuilder(SimpleConfig).from_file(config_file)
-
-        peeked = builder.peek()
-
-        with pytest.warns(DeprecationWarning):
-            raw = builder.get_raw_data()
-
-        assert peeked == raw
-        assert peeked is not raw
-
-    def test_peek_is_nondestructive(self, temp_dir: Path) -> None:
-        """Test that mutating the dict returned by peek() does not affect
-        the builder's internal state.
-
-        Parameters
-        ----------
-        temp_dir : Path
-            Fixture providing a temporary directory.
-        """
-        config_file = temp_dir / "config.json"
-        config_file.write_text('{"port": 5000}')
-
-        builder = ConfigBuilder(SimpleConfig).from_file(config_file)
-
-        snapshot = builder.peek()
-        snapshot["port"] = 99999
-
-        assert builder.peek()["port"] == 5000
+        assert isinstance(config_builder, dict)
+        assert config_builder["app_name"] == "inherited"
+        assert config_builder["port"] == 5000

--- a/uv.lock
+++ b/uv.lock
@@ -340,7 +340,7 @@ wheels = [
 
 [[package]]
 name = "pyconfigr"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
# Description

Extracts the full configuration pipeline into a new `RawConfigBuilder` base class and adds `build_dict()` as the schema-free terminal method. `ConfigBuilder` becomes a thin subclass that adds Pydantic validation via `build()`. All existing `ConfigBuilder` usage is fully backwards-compatible.

---

# Changes

- `src/pyconfigr/builder.py` *(modified)* — two-class split: `RawConfigBuilder` (base, all pipeline logic) + `ConfigBuilder` (extends with `Generic[T]` + `build()`); fluent return types switched to `Self`
- `src/pyconfigr/__init__.py` *(modified)* — export `RawConfigBuilder`, update `__all__` and module docstring
- `pyproject.toml` *(modified)* — bump version to `0.2.0`
- `uv.lock` *(modified)* — regenerated for version bump
- `tests/unit/test_builder.py` *(modified)* — expanded from 18 to 57 tests; added 39 `RawConfigBuilder` parent tests + 3 inheritance tests; merged from separate `test_raw_config_builder.py`
- `tests/conftest.py` *(modified)* — fixture `app_name` values made format-specific (`_yaml`, `_json`, `_toml`)
- `tests/unit/loaders/test_yaml.py` *(modified)* — updated assertions for format-specific `app_name`
- `tests/unit/loaders/test_json.py` *(modified)* — updated assertions for format-specific `app_name`
- `tests/unit/loaders/test_toml.py` *(modified)* — updated assertions for format-specific `app_name`
- `tests/unit/loaders/test_manager.py` *(modified)* — updated assertions for format-specific `app_name`
- `CHANGELOG.md` *(modified)* — added v0.2.0 entry
- `README.md` *(modified)* — updated version, test count, added `RawConfigBuilder` examples

---

# Self-review

- **Static checks:**
  - [x] `ruff check src/ tests/` — all checks passed
  - [x] `mypy src/` — no issues found in 10 source files
  - [x] `pytest -q` — 200 passed, 100% coverage

- **CI checks:**
  - [x] CI passes on all matrix versions (3.10 – 3.14)

- **Additional verification:**

  | Scenario | Expected | Actual |
  |----------|----------|--------|
  | `RawConfigBuilder().from_dict({"k": "v"}).build_dict()` | `{"k": "v"}` | `{"k": "v"}` ✅ |
  | `isinstance(ConfigBuilder(Model), RawConfigBuilder)` | `True` | `True` ✅ |
  | `ConfigBuilder(Model).build()` returns validated model | Pydantic model | Pydantic model ✅ |
  | Fluent chain on `ConfigBuilder` returns `Self` | `ConfigBuilder` type | `ConfigBuilder` type ✅ |

---

# Checklist

- [x] Tests added or updated
- [x] CHANGELOG updated
- [x] Documentation updated
- [x] CI passes

---

Closes #68 