### PR TITLE
[Release] v0.2.0a1 — TestPyPI pipeline validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyconfigre"
-version = "0.2.0"
+version = "0.2.0a1"
 description = "Flexible configuration management with Pydantic validation, YAML/JSON/TOML support, and fluent API"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyconfigre/__init__.py
+++ b/src/pyconfigre/__init__.py
@@ -66,7 +66,7 @@ from .exceptions import (
 try:
     __version__ = version("pyconfigre")
 except PackageNotFoundError:  # pragma: no cover
-    __version__ = "0.2.0.dev0"
+    __version__ = "0.2.0a1"
 
 __all__ = [
     "ConfigBuilder",

--- a/uv.lock
+++ b/uv.lock
@@ -340,7 +340,7 @@ wheels = [
 
 [[package]]
 name = "pyconfigre"
-version = "0.2.0"
+version = "0.2.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
# Description

Bumps version to `0.2.0a1` for the TestPyPI alpha release. After merge, a GitHub Release with tag `v0.2.0a1` triggers the publish workflow targeting TestPyPI for end-to-end pipeline validation.

`PUBLISH_TARGET` is already set to `"testpypi"` (from the `dev` → `main` sync) — only the version bump is needed.

---

# Changes

- `pyproject.toml` *(modified)* — `version = "0.2.0"` → `version = "0.2.0a1"`
- `src/pyconfigre/__init__.py` *(modified)* — fallback `__version__` changed from `"0.2.0.dev0"` → `"0.2.0a1"`
- `uv.lock` *(modified)* — regenerated for version bump

---

# Changes checklist

- [x] `pyproject.toml` version bumped to `0.2.0a1`
- [x] `__init__.py` fallback `__version__` updated to `"0.2.0a1"`
- [x] `uv lock` regenerated
