### PR TITLE
[Release] v0.2.0rc1 — Production PyPI release candidate

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -30,7 +30,7 @@ on:
 
 env:
     UV_VERSION: "0.9.2"
-    PUBLISH_TARGET: "testpypi"
+    PUBLISH_TARGET: "pypi"
 
 jobs:
   validate-tag:

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ chmod 600 config/production.yaml
 
 | Aspect | Status |
 |--------|--------|
-| **Version** | 0.2.0 |
+| **Version** | 0.2.0rc1 |
 | **Python Support** | 3.10, 3.11, 3.12, 3.13, 3.14 |
 | **Test Coverage** | ~100% (200 tests) |
 | **Type Checking** | Full MyPy strict compliance |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyconfigre"
-version = "0.2.0a1"
+version = "0.2.0rc1"
 description = "Flexible configuration management with Pydantic validation, YAML/JSON/TOML support, and fluent API"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyconfigre/__init__.py
+++ b/src/pyconfigre/__init__.py
@@ -66,7 +66,7 @@ from .exceptions import (
 try:
     __version__ = version("pyconfigre")
 except PackageNotFoundError:  # pragma: no cover
-    __version__ = "0.2.0a1"
+    __version__ = "0.2.0rc1"
 
 __all__ = [
     "ConfigBuilder",

--- a/uv.lock
+++ b/uv.lock
@@ -340,7 +340,7 @@ wheels = [
 
 [[package]]
 name = "pyconfigre"
-version = "0.2.0a1"
+version = "0.2.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
# Description

Bumps version to `0.2.0rc1` and switches the publish workflow from TestPyPI to production PyPI. After merge, a GitHub Release with tag `v0.2.0rc1` triggers the publish workflow targeting production PyPI. This is the first publish to the real PyPI index.

---

# Changes

- `pyproject.toml` *(modified)* — `version = "0.2.0a1"` → `version = "0.2.0rc1"`
- `src/pyconfigre/__init__.py` *(modified)* — fallback `__version__` changed from `"0.2.0a1"` → `"0.2.0rc1"`
- `uv.lock` *(modified)* — regenerated for version bump
- `.github/workflows/pypi-publish.yml` *(modified)* — `PUBLISH_TARGET` env var changed from `"testpypi"` to `"pypi"` (dynamically switches GitHub Environment, repository-url, and verify source)
- `README.md` *(modified)* — updated Project Status table version to `0.2.0rc1`

---

# Changes checklist

- [x] `pyproject.toml` version bumped to `0.2.0rc1`
- [x] `__init__.py` fallback `__version__` updated to `"0.2.0rc1"`
- [x] `uv lock` regenerated
- [x] `pypi-publish.yml` `PUBLISH_TARGET` changed to `"pypi"`
