### PR TITLE
[Release] `v0.2.0` — Stable Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - Unreleased
+## [0.2.0] - 2026-05-26
 
 ### ✨ New Features
 

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ chmod 600 config/production.yaml
 
 | Aspect | Status |
 |--------|--------|
-| **Version** | 0.2.0rc1 |
+| **Version** | 0.2.0 |
 | **Python Support** | 3.10, 3.11, 3.12, 3.13, 3.14 |
 | **Test Coverage** | ~100% (200 tests) |
 | **Type Checking** | Full MyPy strict compliance |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyconfigre"
-version = "0.2.0rc1"
+version = "0.2.0"
 description = "Flexible configuration management with Pydantic validation, YAML/JSON/TOML support, and fluent API"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyconfigre/__init__.py
+++ b/src/pyconfigre/__init__.py
@@ -66,7 +66,7 @@ from .exceptions import (
 try:
     __version__ = version("pyconfigre")
 except PackageNotFoundError:  # pragma: no cover
-    __version__ = "0.2.0rc1"
+    __version__ = "0.2.0"
 
 __all__ = [
     "ConfigBuilder",

--- a/uv.lock
+++ b/uv.lock
@@ -340,7 +340,7 @@ wheels = [
 
 [[package]]
 name = "pyconfigre"
-version = "0.2.0rc1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
# Description

Bumps version to `0.2.0` and sets the release date in `CHANGELOG`. After merge, a GitHub Release with tag `v0.2.0` triggers the publish workflow. This is the final stable release — `pip install pyconfigre` will install this version.

---

# Changes

- `pyproject.toml` *(modified)* — `version = "0.2.0rc1"` → `version = "0.2.0"`
- `src/pyconfigre/__init__.py` *(modified)* — fallback `__version__` changed from `"0.2.0rc1"` → `"0.2.0"`
- `uv.lock` *(modified)* — regenerated for version bump
- `CHANGELOG.md` *(modified)* — `Unreleased` → actual release date
- `README.md` *(modified)* — updated Project Status table version to `0.2.0`

---

# Changes checklist

- [x] `pyproject.toml` version bumped to `0.2.0`
- [x] `__init__.py` fallback `__version__` updated to `"0.2.0"`
- [x] `uv lock` regenerated
- [x] `CHANGELOG.md` release date set